### PR TITLE
[FE] eslint 미적용 문법 수정 및 최신 문법 적용

### DIFF
--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -5,20 +5,19 @@ import globals from "globals";
 import tseslint from "typescript-eslint";
 
 export default tseslint.configs(
+    js.configs.recommended,
+    ...tseslint.configs.recommended,
+    pluginReact.configs.flat.recommended,
     {
         files: ["**/*.{js,mjs,cjs,ts,mts,cts,jsx,tsx}"],
         plugins: {
-            js,
             "simple-import-sort": simpleImportSort,
         },
-        extends: ["js/recommended"],
-        languageOptions: { globals: globals.browser },
+        languageOptions: { ...globals.browser },
         rules: {
             "react/react-in-jsx-scope": "off",
             "simple-import-sort/imports": "error",
             "simple-import-sort/exports": "error",
         },
     },
-    tseslint.configs.recommended,
-    pluginReact.configs.flat.recommended,
 );

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -1,11 +1,10 @@
 import js from "@eslint/js";
 import pluginReact from "eslint-plugin-react";
 import simpleImportSort from "eslint-plugin-simple-import-sort";
-import { defineConfig } from "eslint/config";
 import globals from "globals";
 import tseslint from "typescript-eslint";
 
-export default defineConfig([
+export default tseslint.configs(
     {
         files: ["**/*.{js,mjs,cjs,ts,mts,cts,jsx,tsx}"],
         plugins: {
@@ -22,4 +21,4 @@ export default defineConfig([
     },
     tseslint.configs.recommended,
     pluginReact.configs.flat.recommended,
-]);
+);

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -15,7 +15,7 @@ export default defineConfig([
         extends: ["js/recommended"],
         languageOptions: { globals: globals.browser },
         rules: {
-            "react/react-in-jsx-scope": false,
+            "react/react-in-jsx-scope": "off",
             "simple-import-sort/imports": "error",
             "simple-import-sort/exports": "error",
         },


### PR DESCRIPTION
close #82

# 목적
기존 eslint 파일에 false로 적용한 rule 규칙에서 false가 없는 옵션으로 에러 발생 혹은 무시되는 문제를 해결했습니다.
추가로 eslint 수정하는 김에 레거시 문법 대신 최신ESLint(v9+) 으로 업데이트했습니다.

# 작업 내용

구분 | 변경 전 (Legacy / 이전 방식) | 변경 후 (Flat Config / 권장 방식) | 이유 및 효과 (작성하신 내용)
-- | -- | -- | --
설정 함수 | defineConfig([...]) 및 [] 사용 | tseslint.config(...) 및 [] 삭제 | 기존 defineConfig와 []로 감싸는 문법은 오타가 났을 때 eslint 적용하여 에러를 알려주지 않으나, 타입추론을 더 정확하게 지원하는 tseslint.config()는 에러를 알려줌.
설정 순서 | 추천 설정을 뒤에 배치 | 추천 설정을 앞으로 이동 | 추천 설정을 뒤로 빼면 커스텀 규칙보다 우선순위가 높아져서 커스텀 규칙을 덮어쓰게 됨.
확장 문법 | extends: ["eslint:recommended"] | 배열에 설정 객체 나열 | 기존 방식은 레거시이므로, 직관적으로 변경함.
규칙 값 | "rule": false | "rule": "off" | false는 지원하지 않는 옵션임.
