### PR TITLE
[FE] alias를 사용하기 위해 vite config 세팅

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,8 +1,13 @@
+// https://vite.dev/config/
+
 import tailwindcss from "@tailwindcss/vite";
 import react from "@vitejs/plugin-react";
 import { defineConfig } from "vite";
-// https://vite.dev/config/
+import path from "path";
 
 export default defineConfig({
     plugins: [react(), tailwindcss()],
+    resolve: {
+        alias: [{ find: "@shared", replacement: path.resolve(__dirname, "src/shared") }],
+    },
 });


### PR DESCRIPTION
close #85 

# 문제
@shared 경로로 import하면 vite에서 해석하지 못하는 오류가 발생합니다.

# 작업 내용
기존에는 alias적용을 위해 tsconfig에만 설정해주었었습니다. 
다만 tsconfig는 정적으로 IDE에서 오류를 알려주는 용도입니다. 빌드할 땐 사용하지 않고 
vite는 실제로 빌드했을 때 alias를 실제로 어떤 경로로 해석할 지 알려줄 필요가 있습니다.

그래서 vite에도 alias를 어떻게 해석할 지 작성해주었습니다.

# 결과
잘 됩니다.
