### PR TITLE
[FE] Chip 컴포넌트 구현

### DIFF
--- a/frontend/src/shared/components/chip/Chip.tsx
+++ b/frontend/src/shared/components/chip/Chip.tsx
@@ -1,0 +1,50 @@
+import { COLOR_SET } from "@shared/styles/color_set";
+import { cva, VariantProps } from "class-variance-authority";
+import { ComponentPropsWithoutRef, ReactNode } from "react";
+
+type AllowedElementType = "button" | "span";
+
+type Props<T extends AllowedElementType> = ComponentPropsWithoutRef<T> &
+    VariantProps<typeof variants> & {
+        as?: T;
+        leftSlot?: ReactNode;
+    };
+
+const Chip = <T extends AllowedElementType = "button">({
+    variant = "primary",
+    size = "md",
+    leftSlot,
+    children,
+    as,
+    ...rest
+}: Props<T>) => {
+    const Component = as ? as : "button";
+
+    return (
+        <Component className={variants({ variant, size })} {...rest}>
+            {leftSlot ? leftSlot : null}
+
+            {children}
+        </Component>
+    );
+};
+
+const variants = cva("rounded-4xl flex flex-row items-center", {
+    variants: {
+        variant: {
+            primary: [COLOR_SET.primary],
+            secondary: [COLOR_SET.secondary],
+            tertiary_outlined: [COLOR_SET.tertiary_outlined],
+            quaternary: [COLOR_SET.quaternary],
+            quaternary_accent_outlined: [COLOR_SET.quaternary_accent_outlined],
+            basic: [COLOR_SET.basic],
+            notification: [COLOR_SET.notification],
+        },
+        size: {
+            md: "typo-caption-14-medium py-2 px-3 h-9 gap-2",
+            sm: "typo-caption-12-medium py-1 px-2.5 h-6 gap-1",
+        },
+    },
+});
+
+export default Chip;


### PR DESCRIPTION
close #70

# 작업 내용
### ➊ button으로 사용될 때도 있고 그냥 꾸미는 요소로만 사용될 때도 있다
as prop으로 "span", "button"만 노출하여 적절한 태그를 골라 쓸 수 있게 했다. 
기본 값은 "button"이다.

### ➋ 아이콘이 있는 경우가 있다. 
leftSlot으로 넣을 수 있다. 이때 Icon의 컬러를 지정해주지 않는다면, text 컬러를 자동으로 사용한다.

<br />
<br />

# 결과
<img width="1194" height="1080" alt="image" src="https://github.com/user-attachments/assets/0befb11b-eb23-409e-a856-b75974bbdeef" />


