### PR TITLE
[BE] Swagger 추가

### DIFF
--- a/backend/api/build.gradle
+++ b/backend/api/build.gradle
@@ -27,6 +27,8 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-webmvc'
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0'
+
 	runtimeOnly 'com.mysql:mysql-connector-j'
 
 	compileOnly 'org.projectlombok:lombok'

--- a/backend/api/src/main/java/com/yat2/episode/global/SwaggerConfig.java
+++ b/backend/api/src/main/java/com/yat2/episode/global/SwaggerConfig.java
@@ -7,29 +7,34 @@ import io.swagger.v3.oas.models.security.SecurityScheme;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+import java.util.List;
+
 @Configuration
 public class SwaggerConfig {
 
     @Bean
     public OpenAPI openAPI() {
+        SecurityScheme accessTokenScheme = new SecurityScheme()
+                .type(SecurityScheme.Type.APIKEY)
+                .in(SecurityScheme.In.COOKIE)
+                .name("access_token")
+                .description("입력하지 마시고, 로그인 api를 실행해주세요.");
+
+        SecurityScheme refreshTokenScheme = new SecurityScheme()
+                .type(SecurityScheme.Type.APIKEY)
+                .in(SecurityScheme.In.COOKIE)
+                .name("refresh_token")
+                .description("입력하지 마시고, 로그인 api를 실행해주세요.");
+
+        Components components = new Components()
+                .addSecuritySchemes("COOKIE_ACCESS_TOKEN", accessTokenScheme)
+                .addSecuritySchemes("COOKIE_REFRESH_TOKEN", refreshTokenScheme);
+
+        SecurityRequirement globalRequirement = new SecurityRequirement()
+                .addList("COOKIE_ACCESS_TOKEN");
+
         return new OpenAPI()
-                .addSecurityItem(new SecurityRequirement()
-                        .addList("COOKIE_ACCESS_TOKEN")
-                        .addList("COOKIE_REFRESH_TOKEN")
-                )
-                .components(new Components()
-                        .addSecuritySchemes("COOKIE_ACCESS_TOKEN",
-                                new SecurityScheme()
-                                        .type(SecurityScheme.Type.APIKEY)
-                                        .in(SecurityScheme.In.COOKIE)
-                                        .name("access_token")
-                        )
-                        .addSecuritySchemes("COOKIE_REFRESH_TOKEN",
-                                new SecurityScheme()
-                                        .type(SecurityScheme.Type.APIKEY)
-                                        .in(SecurityScheme.In.COOKIE)
-                                        .name("refresh_token")
-                                )
-                );
+                .components(components)
+                .security(List.of(globalRequirement));
     }
 }

--- a/backend/api/src/main/java/com/yat2/episode/global/SwaggerConfig.java
+++ b/backend/api/src/main/java/com/yat2/episode/global/SwaggerConfig.java
@@ -9,6 +9,8 @@ import org.springframework.context.annotation.Configuration;
 
 import java.util.List;
 
+import static com.yat2.episode.global.constant.cookieConstants.*;
+
 @Configuration
 public class SwaggerConfig {
 
@@ -17,21 +19,21 @@ public class SwaggerConfig {
         SecurityScheme accessTokenScheme = new SecurityScheme()
                 .type(SecurityScheme.Type.APIKEY)
                 .in(SecurityScheme.In.COOKIE)
-                .name("access_token")
+                .name(ACCESS_TOKEN)
                 .description("입력하지 마시고, 로그인 api를 실행해주세요.");
 
         SecurityScheme refreshTokenScheme = new SecurityScheme()
                 .type(SecurityScheme.Type.APIKEY)
                 .in(SecurityScheme.In.COOKIE)
-                .name("refresh_token")
+                .name(REFRESH_TOKEN)
                 .description("입력하지 마시고, 로그인 api를 실행해주세요.");
 
         Components components = new Components()
-                .addSecuritySchemes("COOKIE_ACCESS_TOKEN", accessTokenScheme)
-                .addSecuritySchemes("COOKIE_REFRESH_TOKEN", refreshTokenScheme);
+                .addSecuritySchemes(SWAGGER_ACCESS_TOKEN, accessTokenScheme)
+                .addSecuritySchemes(SWAGGER_REFRESH_TOKEN, refreshTokenScheme);
 
         SecurityRequirement globalRequirement = new SecurityRequirement()
-                .addList("COOKIE_ACCESS_TOKEN");
+                .addList(SWAGGER_ACCESS_TOKEN);
 
         return new OpenAPI()
                 .components(components)

--- a/backend/api/src/main/java/com/yat2/episode/global/SwaggerConfig.java
+++ b/backend/api/src/main/java/com/yat2/episode/global/SwaggerConfig.java
@@ -1,0 +1,35 @@
+package com.yat2.episode.global;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+                .addSecurityItem(new SecurityRequirement()
+                        .addList("COOKIE_ACCESS_TOKEN")
+                        .addList("COOKIE_REFRESH_TOKEN")
+                )
+                .components(new Components()
+                        .addSecuritySchemes("COOKIE_ACCESS_TOKEN",
+                                new SecurityScheme()
+                                        .type(SecurityScheme.Type.APIKEY)
+                                        .in(SecurityScheme.In.COOKIE)
+                                        .name("access_token")
+                        )
+                        .addSecuritySchemes("COOKIE_REFRESH_TOKEN",
+                                new SecurityScheme()
+                                        .type(SecurityScheme.Type.APIKEY)
+                                        .in(SecurityScheme.In.COOKIE)
+                                        .name("refresh_token")
+                                )
+                );
+    }
+}

--- a/backend/api/src/main/java/com/yat2/episode/global/constant/cookieConstants.java
+++ b/backend/api/src/main/java/com/yat2/episode/global/constant/cookieConstants.java
@@ -1,0 +1,8 @@
+package com.yat2.episode.global.constant;
+
+public class cookieConstants {
+    public static final String ACCESS_TOKEN = "access_token";
+    public static final String REFRESH_TOKEN = "refresh_token";
+    public static final String SWAGGER_ACCESS_TOKEN = "COOKIE_ACCESS_TOKEN";
+    public static final String SWAGGER_REFRESH_TOKEN = "COOKIE_REFRESH_TOKEN";
+}

--- a/backend/api/src/main/java/com/yat2/episode/users/UsersController.java
+++ b/backend/api/src/main/java/com/yat2/episode/users/UsersController.java
@@ -1,5 +1,7 @@
 package com.yat2.episode.users;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -15,6 +17,13 @@ public class UsersController {
         this.usersService = usersService;
     }
 
+    @Operation(
+            summary = "summary 예시",
+            description = "사용자 리스트를 가져옵니다.",
+            security = {
+                    //@SecurityRequirement(name = "COOKIE_ACCESS_TOKEN")
+            }
+    )
     @GetMapping
     public ResponseEntity<List<Users>> getAllUsers() {
         return ResponseEntity.ok(usersService.getAllUsers());


### PR DESCRIPTION
close #102 

# 목적
api 문서 작성 및 공유를 위해 스웨거를 추가했습니다.

# 작업 내용
- 스웨거 추가
- 예시 description 추가
- 전역 security 값으로 쿠키 값 추가
  - 해당 표시는 api에 어떤 security가 필요한지를 명시하기 위해 추가해뒀습니다.
  - 추가 설명
    - 저희 서비스에서는 대부분이 access_token을 쿠키 값으로 필요로 합니다.
    - httpOnly 쿠키로 사용되기 때문에, 스웨거 페이지에서의 입력이 아니라 로그인 api가 선제적으로 실행되어야만 합니다.

# 결과
<img width="1719" height="551" alt="스크린샷 2026-01-24 오후 7 51 12" src="https://github.com/user-attachments/assets/ab55adf7-94c1-4213-8e3c-9c96bc28f897" />
