### PR TITLE
[FE] SquareButton 컴포넌트 구현

### DIFF
--- a/frontend/src/shared/components/icon/Icon.tsx
+++ b/frontend/src/shared/components/icon/Icon.tsx
@@ -6,7 +6,7 @@ type Props = {
     strokeWidth?: number | string;
 };
 
-function Icon({ color = "currentColor", size = 24, strokeWidth = 1, name }: Props) {
+function Icon({ color = "currentColor", size = 24, strokeWidth = 1.6, name }: Props) {
     return (
         <svg
             color={color}

--- a/frontend/src/shared/components/square_button/SquareButton.tsx
+++ b/frontend/src/shared/components/square_button/SquareButton.tsx
@@ -1,0 +1,16 @@
+import { ComponentPropsWithoutRef } from "react";
+
+type Props = ComponentPropsWithoutRef<"button"> & {};
+
+const SquareButton = ({ children, ...rest }: Props) => {
+    return (
+        <button
+            className="flex justify-center items-center h-9 w-9 bg-white outline-1 outline-gray-200 rounded-[10px] shadow-lg text-base-navy"
+            {...rest}
+        >
+            {children}
+        </button>
+    );
+};
+
+export default SquareButton;

--- a/frontend/src/shared/components/square_button/SquareButtonToolTip.tsx
+++ b/frontend/src/shared/components/square_button/SquareButtonToolTip.tsx
@@ -1,0 +1,16 @@
+import { ComponentPropsWithoutRef } from "react";
+
+type Props = ComponentPropsWithoutRef<"div"> & {};
+
+const SquareButtonToolTip = ({ children, ...rest }: Props) => {
+    return (
+        <div
+            className="flex justify-center items-center h-9 px-3 whitespace-nowrap typo-body-14-regular bg-white rounded-[10px] shadow-lg text-gray-800"
+            {...rest}
+        >
+            {children}
+        </div>
+    );
+};
+
+export default SquareButtonToolTip;

--- a/frontend/src/shared/components/tooltip/Tooltip.tsx
+++ b/frontend/src/shared/components/tooltip/Tooltip.tsx
@@ -1,0 +1,30 @@
+import useToggle from "@shared/hooks/useToggle";
+import { ReactNode } from "react";
+
+type Props = {
+    children: ReactNode;
+    contents: ReactNode;
+
+    direction?: "top" | "bottom" | "left" | "right";
+};
+
+const Tooltip = ({ direction = "right", children, contents }: Props) => {
+    const [isVisible, { setOff, setOn }] = useToggle();
+
+    return (
+        <div onPointerOver={setOn} onPointerLeave={setOff} className="relative w-fit">
+            {children}
+
+            {isVisible && <div className={`absolute z-50 ${positionClasses[direction]}`}>{contents}</div>}
+        </div>
+    );
+};
+
+export default Tooltip;
+
+const positionClasses = {
+    top: "bottom-full left-1/2 -translate-x-1/2 mb-2",
+    bottom: "top-full left-1/2 -translate-x-1/2 mt-2",
+    left: "right-full top-1/2 -translate-y-1/2 mr-2",
+    right: "left-full top-1/2 -translate-y-1/2 ml-2",
+};

--- a/frontend/src/shared/components/tooltip/Tooltip.tsx
+++ b/frontend/src/shared/components/tooltip/Tooltip.tsx
@@ -9,10 +9,10 @@ type Props = {
 };
 
 const Tooltip = ({ direction = "right", children, contents }: Props) => {
-    const [isVisible, { setOff, setOn }] = useToggle();
+    const [isVisible, isVisibleHandler] = useToggle({ defaultValue: false });
 
     return (
-        <div onPointerOver={setOn} onPointerLeave={setOff} className="relative w-fit">
+        <div onPointerOver={isVisibleHandler.on} onPointerLeave={isVisibleHandler.off} className="relative w-fit">
             {children}
 
             {isVisible && <div className={`absolute z-50 ${positionClasses[direction]}`}>{contents}</div>}

--- a/frontend/src/shared/hooks/useToggle.ts
+++ b/frontend/src/shared/hooks/useToggle.ts
@@ -1,32 +1,19 @@
-import { useReducer } from "react";
-
-type Action = { type: "ON" } | { type: "OFF" } | { type: "TOGGLE" };
+import { useReducer, useState } from "react";
 
 type Props = {
     defaultValue?: boolean;
 };
 
 const useToggle = ({ defaultValue = false }: Props = {}) => {
-    const [state, dispatch] = useReducer(toggleReducer, defaultValue);
+    const [isToggled, setIsToggled] = useState(defaultValue);
 
-    const setOn = () => dispatch({ type: "ON" });
-    const setOff = () => dispatch({ type: "OFF" });
-    const toggle = () => dispatch({ type: "TOGGLE" });
+    const actionHandler = {
+        on: () => setIsToggled(true),
+        off: () => setIsToggled(false),
+        toggle: () => setIsToggled((prev) => !prev),
+    };
 
-    return [state, { setOn, setOff, toggle }] as const;
+    return [isToggled, actionHandler] as const;
 };
 
 export default useToggle;
-
-function toggleReducer(state: boolean, action: Action): boolean {
-    switch (action.type) {
-        case "ON":
-            return true;
-        case "OFF":
-            return false;
-        case "TOGGLE":
-            return !state;
-        default:
-            return state;
-    }
-}

--- a/frontend/src/shared/hooks/useToggle.ts
+++ b/frontend/src/shared/hooks/useToggle.ts
@@ -1,0 +1,32 @@
+import { useReducer } from "react";
+
+type Action = { type: "ON" } | { type: "OFF" } | { type: "TOGGLE" };
+
+type Props = {
+    defaultValue?: boolean;
+};
+
+const useToggle = ({ defaultValue = false }: Props = {}) => {
+    const [state, dispatch] = useReducer(toggleReducer, defaultValue);
+
+    const setOn = () => dispatch({ type: "ON" });
+    const setOff = () => dispatch({ type: "OFF" });
+    const toggle = () => dispatch({ type: "TOGGLE" });
+
+    return [state, { setOn, setOff, toggle }] as const;
+};
+
+export default useToggle;
+
+function toggleReducer(state: boolean, action: Action): boolean {
+    switch (action.type) {
+        case "ON":
+            return true;
+        case "OFF":
+            return false;
+        case "TOGGLE":
+            return !state;
+        default:
+            return state;
+    }
+}


### PR DESCRIPTION
close #67 

# 목적
<img width="369" height="322" alt="image" src="https://github.com/user-attachments/assets/e7a312c8-8952-4240-a7a2-ea9cf77a8e94" />

<br />
<br />

# 작업 내용
### ➊ tooltip ui를 구현
hover했을 때 뜨는 무언가를 tooltip ui라고 한다고 한다..

원래는 SquareButton에 floatingRight라는 prop을 뚫어 구현하려고 했다. 
그런데 다른 방향이나 다른 컴포넌트에서도 유사한 기능이 있다면 귀찮아지므로 다른 방법을 생각하기로 했다. 

그래서 Radix ui를 좀 보니 Tooltip이라는 컴포넌트를 compound방식으로 사용하고 있었다. 
나는 굳이 compound까지 할 정도로 다양한 옵션을 제공할 필요가 없으므로, 
`children`으로 trigger 요소를 받고, `contents`라는 prop으로 띄울 요소를 받았다. 
방향은 심플하게 상하좌우 가능하게 했다.

그리고 tooltip UI는 overflow할 가능성도 낮고(작아서) 딱히 clamping 로직은 넣지않았다.

<br />

### ➋ useToggle 구현 방법
false <-> true를 와리가리하는 state는 여러 곳에서 사용된다. 
그래서 보통 이걸 훅으로 분리해서 쓰곤 했다. 

최근에 useReducer라는 훅을 배워서 적용해봤다. 
근데 구현하고 보니 useReducer는 복잡한 상태 변경 로직을 숨기기 위해 사용하는 방법이라서, 굳이 라는 생각이 들었다.

그래서 그냥 useState로 다시 바꿨다.

<br />

### ➌ SquareButtonToolTip 컴포넌트
SquareButton에 사용하는 종속적인 UI 요소이므로 이름에 SquareButton을 넣어 따로 분리했다. 
compound로 하지않은 이유는, compound로 만드는건 해당 컴포넌트와 함께 사용해야할 컴포넌트가 많을 경우가 좀 더 직관적이라고 생각해서다. 유관 또는 같은 이름이라고 묶는건 너무 미약한 근거라고 생각된다(이 근거라면 MindMap컴포넌트는 거대한 덩어리가 되어버림)

그래서 분리했다~

<br />


# 결과
잘된다~

<br />

# <ToopTip> 사용법

```jsx
<ToolTip contents={<호버했을 때 뜰거/>} direction={"뜨는 방향"}>
  <호버할거/>
</ToolTip>
```