### PR TITLE
[BE] global exception 핸들러 구현

### DIFF
--- a/backend/api/src/main/java/com/yat2/episode/global/exception/CustomException.java
+++ b/backend/api/src/main/java/com/yat2/episode/global/exception/CustomException.java
@@ -1,0 +1,14 @@
+package com.yat2.episode.global.exception;
+
+import lombok.Getter;
+
+@Getter
+public class CustomException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    public CustomException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+}

--- a/backend/api/src/main/java/com/yat2/episode/global/exception/ErrorCode.java
+++ b/backend/api/src/main/java/com/yat2/episode/global/exception/ErrorCode.java
@@ -5,6 +5,10 @@ import org.springframework.http.HttpStatus;
 
 @Getter
 public enum ErrorCode {
+
+    AUTH_EXPIRED(HttpStatus.UNAUTHORIZED, "AUTH_EXPIRED", "로그인이 만료되었습니다."),
+    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "INVALID_TOKEN", "유효하지 않은 토큰입니다."),
+
     INVALID_REQUEST(HttpStatus.BAD_REQUEST, "INVALID_REQUEST", "잘못된 요청입니다."),
     INTERNAL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "INTERNAL_ERROR", "서버 오류가 발생했습니다.");
 

--- a/backend/api/src/main/java/com/yat2/episode/global/exception/ErrorCode.java
+++ b/backend/api/src/main/java/com/yat2/episode/global/exception/ErrorCode.java
@@ -1,0 +1,20 @@
+package com.yat2.episode.global.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum ErrorCode {
+    INVALID_REQUEST(HttpStatus.BAD_REQUEST, "INVALID_REQUEST", "잘못된 요청입니다."),
+    INTERNAL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "INTERNAL_ERROR", "서버 오류가 발생했습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+
+    ErrorCode(HttpStatus httpStatus, String code, String message) {
+        this.httpStatus = httpStatus;
+        this.code = code;
+        this.message = message;
+    }
+}

--- a/backend/api/src/main/java/com/yat2/episode/global/exception/ErrorResponse.java
+++ b/backend/api/src/main/java/com/yat2/episode/global/exception/ErrorResponse.java
@@ -1,0 +1,29 @@
+package com.yat2.episode.global.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ErrorResponse {
+
+    private int status;
+    private String code;
+    private String message;
+
+    public static ErrorResponse from(ErrorCode errorCode) {
+        return new ErrorResponse(
+                errorCode.getHttpStatus().value(),
+                errorCode.getCode(),
+                errorCode.getMessage()
+        );
+    }
+
+    public static ErrorResponse of(ErrorCode errorCode, String message) {
+        return new ErrorResponse(
+                errorCode.getHttpStatus().value(),
+                errorCode.getCode(),
+                message
+        );
+    }
+}

--- a/backend/api/src/main/java/com/yat2/episode/global/exception/GlobalExceptionHandler.java
+++ b/backend/api/src/main/java/com/yat2/episode/global/exception/GlobalExceptionHandler.java
@@ -1,9 +1,11 @@
 package com.yat2.episode.global.exception;
 
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+@Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
@@ -17,6 +19,7 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ErrorResponse> handleException(Exception e) {
+        log.error("Unhandled exception", e);
         return ResponseEntity
                 .status(ErrorCode.INTERNAL_ERROR.getHttpStatus())
                 .body(ErrorResponse.from(ErrorCode.INTERNAL_ERROR));

--- a/backend/api/src/main/java/com/yat2/episode/global/exception/GlobalExceptionHandler.java
+++ b/backend/api/src/main/java/com/yat2/episode/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,24 @@
+package com.yat2.episode.global.exception;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(CustomException.class)
+    public ResponseEntity<ErrorResponse> handleBusinessException(CustomException e) {
+        ErrorCode errorCode = e.getErrorCode();
+        return ResponseEntity
+                .status(errorCode.getHttpStatus())
+                .body(ErrorResponse.of(errorCode, e.getMessage()));
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponse> handleException(Exception e) {
+        return ResponseEntity
+                .status(ErrorCode.INTERNAL_ERROR.getHttpStatus())
+                .body(ErrorResponse.from(ErrorCode.INTERNAL_ERROR));
+    }
+}


### PR DESCRIPTION
close #102

# 목적
서비스 과정에서 백엔드의 비즈니스 로직 처리 도중 발생할 수 있는 exception을 모아 처리하여, 에러 처리 시간을 줄이고 어떤 문제인지 확인하는 시간을 단축합니다.
프론트엔드 단에서 건의했던, http code 외에 더 세부적으로 어떤 문제인지 파악할 수 있는 message를 첨부합니다.

# 작업 내용
- 커스텀 할 수 있는 errorcode enum 추가
- global handler에 customException 처리 추가

# 결과

<img width="605" height="179" alt="image" src="https://github.com/user-attachments/assets/d5e5fe5a-1a13-4057-9078-c0c87ba6d549" />

