### PR TITLE
[FE] ProfileIcon 컴포넌트 구현

### DIFF
--- a/frontend/src/shared/components/profile_icon/ProfileIcon.tsx
+++ b/frontend/src/shared/components/profile_icon/ProfileIcon.tsx
@@ -1,0 +1,44 @@
+import { cva, type VariantProps } from "class-variance-authority";
+import { cn } from "@utils/cn";
+import { COLOR_SET } from "@shared/styles/color_set";
+
+type Props = VariantProps<typeof profileIconVariants> & {
+    name: string;
+    isOnline?: boolean;
+    className?: string;
+};
+
+const ProfileIcon = ({ size = "md", name, isOnline, className }: Props) => {
+    const initialName = name.trim().charAt(0);
+
+    return (
+        <div className={cn(profileIconVariants({ size }), className)}>
+            {initialName}
+
+            {isOnline && <span className={cn(indicatorVariants({ size }))} />}
+        </div>
+    );
+};
+
+export default ProfileIcon;
+
+const profileIconVariants = cva(
+    `relative flex items-center justify-center rounded-full shrink-0 ${COLOR_SET.tertiary}`,
+    {
+        variants: {
+            size: {
+                md: "w-10 h-10 typo-body-18-semibold",
+                sm: "w-6 h-6 typo-body-10-semibold",
+            },
+        },
+    },
+);
+
+const indicatorVariants = cva("absolute bottom-0 right-0 rounded-full bg-green-300", {
+    variants: {
+        size: {
+            md: "w-3 h-3",
+            sm: "w-1.75 h-1.75",
+        },
+    },
+});


### PR DESCRIPTION
close #76 

# 작업 내용
### ➊ 퍼블리싱과 prop 뚫기
했습니다

### ➋ 이름띄우기
이름 주면 1글자만 떼어서 띄웁니다

<br/>
<br/>

# 결과
<img width="743" height="683" alt="image" src="https://github.com/user-attachments/assets/f0d29d38-ab0e-43bc-aed6-ba175681bc2a" />

