### PR TITLE
[FE] Tab 컴포넌트 구현

### DIFF
--- a/frontend/src/shared/components/tabs/Tab.tsx
+++ b/frontend/src/shared/components/tabs/Tab.tsx
@@ -1,0 +1,29 @@
+import React, { cloneElement, Children, ComponentProps } from "react";
+import TabItem from "./TabItem";
+
+type Props = {
+    children: (React.ReactElement<ComponentProps<typeof TabItem>> | null)[];
+    onChange: (index: number) => void;
+    selectedIndex: number;
+};
+
+const TabComponent = ({ children, onChange, selectedIndex }: Props) => {
+    return (
+        <div className="w-full flex border-b-2 border-gray-200 h-12.5">
+            {Children.map(children, (child, index) => {
+                if (!child) return null;
+
+                return cloneElement(child, {
+                    onClick: () => onChange(index),
+                    isSelected: index === selectedIndex,
+                });
+            })}
+        </div>
+    );
+};
+
+const Tab = Object.assign(TabComponent, {
+    Item: TabItem,
+});
+
+export default Tab;

--- a/frontend/src/shared/components/tabs/Tab.tsx
+++ b/frontend/src/shared/components/tabs/Tab.tsx
@@ -1,8 +1,10 @@
-import React, { cloneElement, Children, ComponentProps } from "react";
+import { cloneElement, Children, ComponentProps, ReactElement } from "react";
 import TabItem from "./TabItem";
 
+type ChildrenType = ReactElement<ComponentProps<typeof TabItem>>;
+
 type Props = {
-    children: (React.ReactElement<ComponentProps<typeof TabItem>> | null)[];
+    children: ChildrenType | ChildrenType[];
     onChange: (index: number) => void;
     selectedIndex: number;
 };

--- a/frontend/src/shared/components/tabs/TabItem.tsx
+++ b/frontend/src/shared/components/tabs/TabItem.tsx
@@ -1,4 +1,4 @@
-import Divider from "../divider/Divider";
+import Divider from "@shared/components/divider/Divider";
 
 type Props = {
     label: string;

--- a/frontend/src/shared/components/tabs/TabItem.tsx
+++ b/frontend/src/shared/components/tabs/TabItem.tsx
@@ -10,7 +10,7 @@ const TabItem = ({ isSelected = false, label, onClick }: Props) => {
     return (
         <button
             onClick={onClick}
-            className={`relative min-w-42 flex items-center justify-center typo-body-16-semibold font-semibold transition-colors ${
+            className={`relative min-w-42 flex items-center justify-center typo-body-16-semibold transition-colors ${
                 isSelected ? "text-primary" : "text-base-navy"
             }`}
         >

--- a/frontend/src/shared/components/tabs/TabItem.tsx
+++ b/frontend/src/shared/components/tabs/TabItem.tsx
@@ -1,0 +1,24 @@
+import Divider from "../divider/Divider";
+
+type Props = {
+    label: string;
+    isSelected?: boolean;
+    onClick?: () => void;
+};
+
+const TabItem = ({ isSelected = false, label, onClick }: Props) => {
+    return (
+        <button
+            onClick={onClick}
+            className={`relative min-w-42 flex items-center justify-center typo-body-16-semibold font-semibold transition-colors ${
+                isSelected ? "text-primary" : "text-base-navy"
+            }`}
+        >
+            {label}
+
+            {isSelected && <Divider className="absolute -bottom-0.5 h-0.5 bg-primary" direction="x" />}
+        </button>
+    );
+};
+
+export default TabItem;


### PR DESCRIPTION
close #121

# 작업 내용
### ➊ `<Tab/>`구현
children으로 TabItem 배열 타입만 받을 수 있게 했습니다.

TabItem에 onClick을 모두 넘겨주는 것보단 Tab하나가 받아서 처리하는게 나으므로, cloneElement로 TabItem에 onChange의 로직을 onClick으로 넘겨 렌더링했습니다. 

isSelected는 외부 관리로 위임해도 어차피 개수 안맞으면 오류나므로, 내부에서 index === selectedIndex로 처리했습니다.

<br />

### ➋`<TabItem/>`구현
figma 시안 상 min-width가 있는 것으로 보여 그렇게 했습니다. 
그래서 줄이면 깨집니다.

<br/>
<br/>

# 결과
잘됩니다~

https://github.com/user-attachments/assets/4b0c43bc-9d48-4b07-bab6-cc255620edd7

<br/>
<br/>

# 기타
애니메이션은 안하겠습니다.. 공수에 비해 그리 큰 개선이 없다고 생각합니다.
