### PR TITLE
[FE] ProgressStep 컴포넌트 구현

### DIFF
--- a/frontend/src/shared/components/progress_step/ProgressStep.tsx
+++ b/frontend/src/shared/components/progress_step/ProgressStep.tsx
@@ -10,12 +10,7 @@ const ProgressStep = ({ onChange, currentStep, length }: Props) => {
     return (
         <div className="flex items-center">
             {arr.map((step) => (
-                <button
-                    key={step}
-                    onClick={onChange ? () => onChange(step) : undefined}
-                    className="p-2 group focus:outline-none"
-                    aria-label={`Go to step ${step + 1}`}
-                >
+                <button key={step} onClick={onChange ? () => onChange(step) : undefined} className="p-2 group">
                     <div
                         className={`w-2.5 h-2.5 rounded-full transition-all duration-200 
                         ${step === currentStep ? "bg-primary scale-125" : "bg-gray-300 group-hover:bg-gray-400"}`}

--- a/frontend/src/shared/components/progress_step/ProgressStep.tsx
+++ b/frontend/src/shared/components/progress_step/ProgressStep.tsx
@@ -1,0 +1,29 @@
+type Props = {
+    length: number;
+    currentStep: number;
+    onChange?: (stepIndex: number) => void;
+};
+
+const ProgressStep = ({ onChange, currentStep, length }: Props) => {
+    const arr = Array.from({ length }, (_, i) => i);
+
+    return (
+        <div className="flex items-center">
+            {arr.map((step) => (
+                <button
+                    key={step}
+                    onClick={onChange ? () => onChange(step) : undefined}
+                    className="p-2 group focus:outline-none"
+                    aria-label={`Go to step ${step + 1}`}
+                >
+                    <div
+                        className={`w-2.5 h-2.5 rounded-full transition-all duration-200 
+                        ${step === currentStep ? "bg-primary scale-125" : "bg-gray-300 group-hover:bg-gray-400"}`}
+                    />
+                </button>
+            ))}
+        </div>
+    );
+};
+
+export default ProgressStep;


### PR DESCRIPTION
close #123 


# 작업 내용
### ➊ 히트박스
8px너무 작아서 클릭이 잘 안되길래 button안에 div넣어서 히트박스를 키웠습니다.

<br/>

### ➋ 점 클릭하면 이동하기
onChange prop 받아서 state변경할 수 있게 했습니다.
근데 꼭 안넘기고 그냥 외부에서 관리하고 싶을 수도 있으니 해당 prop optional로 두었어요.

<br/>

# 결과
잘 됩니다.
애니메이션 넣어도 엄청 간단할 것 같아서 넣어봤어요.

https://github.com/user-attachments/assets/511846b0-64e0-466f-85c6-3b218778023e



