### PR TITLE
[FE] node_center 컴포넌트 구현

### DIFF
--- a/frontend/src/features/mindmap/node/add_node/AddNode.tsx
+++ b/frontend/src/features/mindmap/node/add_node/AddNode.tsx
@@ -3,9 +3,12 @@ import { ComponentPropsWithoutRef, useState } from "react";
 import AddNodeDot from "@features/mindmap/node/add_node/AddNodeDot";
 import AddNodeArrow from "@features/mindmap/node/add_node/AddNodeArrow";
 
-type Props = ComponentPropsWithoutRef<"div"> & NodeComponentProps & {};
+type Props = ComponentPropsWithoutRef<"div"> &
+    NodeComponentProps & {
+        direction: "left" | "right";
+    };
 
-export default function AddNode({ color, ...rest }: Props) {
+export default function AddNode({ color, direction, ...rest }: Props) {
     const [isHovered, setIsHovered] = useState(false);
 
     return (
@@ -21,7 +24,7 @@ export default function AddNode({ color, ...rest }: Props) {
             <div
                 className={`absolute inset-0 flex items-center justify-center transition-opacity duration-300 ${isHovered ? "opacity-100" : "opacity-0"}`}
             >
-                <AddNodeArrow color={color} />
+                <AddNodeArrow color={color} direction={direction} />
             </div>
         </div>
     );

--- a/frontend/src/features/mindmap/node/add_node/AddNode.tsx
+++ b/frontend/src/features/mindmap/node/add_node/AddNode.tsx
@@ -1,29 +1,21 @@
 import { type NodeComponentProps } from "@features/mindmap/node/types/node";
-import { ComponentPropsWithoutRef, useState } from "react";
+import { ComponentPropsWithoutRef } from "react";
 import AddNodeDot from "@features/mindmap/node/add_node/AddNodeDot";
 import AddNodeArrow from "@features/mindmap/node/add_node/AddNodeArrow";
+import { cn } from "@utils/cn";
 
 type Props = ComponentPropsWithoutRef<"div"> &
     NodeComponentProps & {
         direction: "left" | "right";
     };
 
-export default function AddNode({ color, direction, ...rest }: Props) {
-    const [isHovered, setIsHovered] = useState(false);
-
+export default function AddNode({ color, direction, className, ...rest }: Props) {
     return (
-        <div
-            {...rest}
-            onMouseEnter={() => setIsHovered(true)}
-            onMouseLeave={() => setIsHovered(false)}
-            className="relative w-13.5 h-13.5 flex items-center justify-center"
-        >
-            <div className={`transition-opacity duration-300 ${isHovered ? "opacity-0" : "opacity-100"}`}>
+        <div {...rest} className={cn("relative w-13.5 h-13.5 flex items-center justify-center", className)}>
+            <div className="transition-opacity duration-300">
                 <AddNodeDot color={color} />
             </div>
-            <div
-                className={`absolute inset-0 flex items-center justify-center transition-opacity duration-300 ${isHovered ? "opacity-100" : "opacity-0"}`}
-            >
+            <div className="absolute inset-0 flex items-center justify-center transition-opacity duration-300 hover:opacity-100 opacity-0">
                 <AddNodeArrow color={color} direction={direction} />
             </div>
         </div>

--- a/frontend/src/features/mindmap/node/add_node/AddNode.tsx
+++ b/frontend/src/features/mindmap/node/add_node/AddNode.tsx
@@ -3,13 +3,13 @@ import { ComponentPropsWithoutRef, useState } from "react";
 import AddNodeDot from "@features/mindmap/node/add_node/AddNodeDot";
 import AddNodeArrow from "@features/mindmap/node/add_node/AddNodeArrow";
 
-type Props = ComponentPropsWithoutRef<"button"> & NodeComponentProps & {};
+type Props = ComponentPropsWithoutRef<"div"> & NodeComponentProps & {};
 
-export default function AddNodeButton({ color, ...rest }: Props) {
+export default function AddNode({ color, ...rest }: Props) {
     const [isHovered, setIsHovered] = useState(false);
 
     return (
-        <button
+        <div
             {...rest}
             onMouseEnter={() => setIsHovered(true)}
             onMouseLeave={() => setIsHovered(false)}
@@ -23,6 +23,6 @@ export default function AddNodeButton({ color, ...rest }: Props) {
             >
                 <AddNodeArrow color={color} />
             </div>
-        </button>
+        </div>
     );
 }

--- a/frontend/src/features/mindmap/node/add_node/AddNodeArrow.tsx
+++ b/frontend/src/features/mindmap/node/add_node/AddNodeArrow.tsx
@@ -1,8 +1,24 @@
 import IcIconMove from "@icons/ic_tool_move.svg?react";
 import { cn } from "@utils/cn";
 import { getNodeColorClass, NodeColor } from "@features/mindmap/node/constants/colors";
+import { ComponentPropsWithoutRef } from "react";
+import { cva, VariantProps } from "class-variance-authority";
 
-export default function AddNodeArrow({ color }: { color: NodeColor }) {
+type Props = Omit<ComponentPropsWithoutRef<"button">, "color"> &
+    VariantProps<typeof DirectionProps> & {
+        color: NodeColor;
+    };
+
+const DirectionProps = cva("w-5 h-6 text-base-white", {
+    variants: {
+        direction: {
+            left: "rotate-310",
+            right: "rotate-135",
+        },
+    },
+});
+
+export default function AddNodeArrow({ color, direction, className, ...rest }: Props) {
     const handleAddNode = () => {
         // TODO: menu 컴포넌트 생성
     };
@@ -15,7 +31,7 @@ export default function AddNodeArrow({ color }: { color: NodeColor }) {
     return (
         <button onClick={handleAddNode} className={outerCircleClass}>
             <div className={iconCircleClass}>
-                <IcIconMove className="w-5 h-6 text-base-white rotate-135" />
+                <IcIconMove className={cn(DirectionProps({ direction }))} />
             </div>
         </button>
     );

--- a/frontend/src/features/mindmap/node/add_node/AddNodeArrow.tsx
+++ b/frontend/src/features/mindmap/node/add_node/AddNodeArrow.tsx
@@ -31,7 +31,7 @@ export default function AddNodeArrow({ color, direction, className, ...rest }: P
     return (
         <button onClick={handleAddNode} className={outerCircleClass}>
             <div className={iconCircleClass}>
-                <IcIconMove className={cn(DirectionProps({ direction }))} />
+                <IcIconMove className={cn(DirectionProps({ direction }), className)} />
             </div>
         </button>
     );

--- a/frontend/src/features/mindmap/node/node_center/NodeCenter.tsx
+++ b/frontend/src/features/mindmap/node/node_center/NodeCenter.tsx
@@ -1,0 +1,19 @@
+import { useState } from "react";
+import AddNodeButton from "@features/mindmap/node/add_node/AddNodeButton";
+
+export default function NodeCenter() {
+    const [isHover, setIsHover] = useState(false);
+    return (
+        <div
+            className="group flex items-center gap-2"
+            onMouseEnter={() => setIsHover(true)}
+            onMouseLeave={() => setIsHover(false)}
+        >
+            {isHover && <AddNodeButton color="violet" />}
+            <div className="cursor-pointer w-40 bg-primary rounded-full h-40 flex items-center justify-center text-white typo-body-16-semibold">
+                sdfsd
+            </div>
+            {isHover && <AddNodeButton color="violet" />}
+        </div>
+    );
+}

--- a/frontend/src/features/mindmap/node/node_center/NodeCenter.tsx
+++ b/frontend/src/features/mindmap/node/node_center/NodeCenter.tsx
@@ -5,7 +5,7 @@ type Props = ComponentPropsWithoutRef<"div"> & {
     username?: string;
 };
 
-const primary_color = "violet";
+const PRIMARY_COLOR = "violet";
 
 export default function NodeCenter({ username = "", className, ...rest }: Props) {
     const [isHover, setIsHover] = useState(false);
@@ -18,11 +18,11 @@ export default function NodeCenter({ username = "", className, ...rest }: Props)
             onMouseLeave={() => setIsHover(false)}
             {...rest}
         >
-            {isHover && <AddNode color={primary_color} direction="left" />}
+            {isHover && <AddNode color={PRIMARY_COLOR} direction="left" />}
             <div className="cursor-pointer w-40 bg-primary rounded-full h-40 flex items-center justify-center text-white typo-body-16-semibold px-3 whitespace-pre-line">
                 {label}
             </div>
-            {isHover && <AddNode color={primary_color} direction="right" />}
+            {isHover && <AddNode color={PRIMARY_COLOR} direction="right" />}
         </div>
     );
 }

--- a/frontend/src/features/mindmap/node/node_center/NodeCenter.tsx
+++ b/frontend/src/features/mindmap/node/node_center/NodeCenter.tsx
@@ -1,19 +1,26 @@
-import { useState } from "react";
-import AddNodeButton from "@features/mindmap/node/add_node/AddNodeButton";
+import { ComponentPropsWithoutRef, useState } from "react";
+import AddNode from "@features/mindmap/node/add_node/AddNode";
 
-export default function NodeCenter() {
+type Props = ComponentPropsWithoutRef<"div"> & {
+    username?: string;
+};
+
+export default function NodeCenter({ username = "", className, ...rest }: Props) {
     const [isHover, setIsHover] = useState(false);
+    const label = username ? `${username}의 마인드맵` : "마인드맵";
+
     return (
         <div
-            className="group flex items-center gap-2"
+            className={`group flex items-center gap-2 ${className ?? ""}`}
             onMouseEnter={() => setIsHover(true)}
             onMouseLeave={() => setIsHover(false)}
+            {...rest}
         >
-            {isHover && <AddNodeButton color="violet" />}
-            <div className="cursor-pointer w-40 bg-primary rounded-full h-40 flex items-center justify-center text-white typo-body-16-semibold">
-                sdfsd
+            {isHover && <AddNode color="violet" />}
+            <div className="cursor-pointer w-40 bg-primary rounded-full h-40 flex items-center justify-center text-white typo-body-16-semibold px-3 text-center leading-tight">
+                {label}
             </div>
-            {isHover && <AddNodeButton color="violet" />}
+            {isHover && <AddNode color="violet" />}
         </div>
     );
 }

--- a/frontend/src/features/mindmap/node/node_center/NodeCenter.tsx
+++ b/frontend/src/features/mindmap/node/node_center/NodeCenter.tsx
@@ -5,6 +5,8 @@ type Props = ComponentPropsWithoutRef<"div"> & {
     username?: string;
 };
 
+const primary_color = "violet";
+
 export default function NodeCenter({ username = "", className, ...rest }: Props) {
     const [isHover, setIsHover] = useState(false);
     const label = username ? `${username}의\n마인드맵` : "마인드맵";
@@ -16,11 +18,11 @@ export default function NodeCenter({ username = "", className, ...rest }: Props)
             onMouseLeave={() => setIsHover(false)}
             {...rest}
         >
-            {isHover && <AddNode color="violet" direction="left" />}
+            {isHover && <AddNode color={primary_color} direction="left" />}
             <div className="cursor-pointer w-40 bg-primary rounded-full h-40 flex items-center justify-center text-white typo-body-16-semibold px-3 whitespace-pre-line">
                 {label}
             </div>
-            {isHover && <AddNode color="violet" direction="right" />}
+            {isHover && <AddNode color={primary_color} direction="right" />}
         </div>
     );
 }

--- a/frontend/src/features/mindmap/node/node_center/NodeCenter.tsx
+++ b/frontend/src/features/mindmap/node/node_center/NodeCenter.tsx
@@ -1,4 +1,4 @@
-import { ComponentPropsWithoutRef, useState } from "react";
+import { ComponentPropsWithoutRef } from "react";
 import AddNode from "@features/mindmap/node/add_node/AddNode";
 
 type Props = ComponentPropsWithoutRef<"div"> & {
@@ -8,21 +8,23 @@ type Props = ComponentPropsWithoutRef<"div"> & {
 const PRIMARY_COLOR = "violet";
 
 export default function NodeCenter({ username = "", className, ...rest }: Props) {
-    const [isHover, setIsHover] = useState(false);
     const label = username ? `${username}의\n마인드맵` : "마인드맵";
 
     return (
-        <div
-            className={`group flex items-center gap-2 ${className ?? ""}`}
-            onMouseEnter={() => setIsHover(true)}
-            onMouseLeave={() => setIsHover(false)}
-            {...rest}
-        >
-            {isHover && <AddNode color={PRIMARY_COLOR} direction="left" />}
-            <div className="cursor-pointer w-40 bg-primary rounded-full h-40 flex items-center justify-center text-white typo-body-16-semibold px-3 whitespace-pre-line">
+        <div className={`group flex items-center gap-2 ${className ?? ""}`} {...rest}>
+            <AddNode
+                color={PRIMARY_COLOR}
+                direction="left"
+                className="opacity-0 group-hover:opacity-100 transition-opacity duration-300 pointer-events-none group-hover:pointer-events-auto"
+            />
+            <div className="cursor-pointer w-40 bg-node-violet-op-100 rounded-full h-40 flex items-center justify-center text-white typo-body-16-semibold px-3 whitespace-pre-line">
                 {label}
             </div>
-            {isHover && <AddNode color={PRIMARY_COLOR} direction="right" />}
+            <AddNode
+                color={PRIMARY_COLOR}
+                direction="right"
+                className="opacity-0 group-hover:opacity-100 transition-opacity duration-300 pointer-events-none group-hover:pointer-events-auto"
+            />
         </div>
     );
 }

--- a/frontend/src/features/mindmap/node/node_center/NodeCenter.tsx
+++ b/frontend/src/features/mindmap/node/node_center/NodeCenter.tsx
@@ -7,7 +7,7 @@ type Props = ComponentPropsWithoutRef<"div"> & {
 
 export default function NodeCenter({ username = "", className, ...rest }: Props) {
     const [isHover, setIsHover] = useState(false);
-    const label = username ? `${username}의 마인드맵` : "마인드맵";
+    const label = username ? `${username}의\n마인드맵` : "마인드맵";
 
     return (
         <div
@@ -17,7 +17,7 @@ export default function NodeCenter({ username = "", className, ...rest }: Props)
             {...rest}
         >
             {isHover && <AddNode color="violet" />}
-            <div className="cursor-pointer w-40 bg-primary rounded-full h-40 flex items-center justify-center text-white typo-body-16-semibold px-3 text-center leading-tight">
+            <div className="cursor-pointer w-40 bg-primary rounded-full h-40 flex items-center justify-center text-white typo-body-16-semibold px-3 whitespace-pre-line">
                 {label}
             </div>
             {isHover && <AddNode color="violet" />}

--- a/frontend/src/features/mindmap/node/node_center/NodeCenter.tsx
+++ b/frontend/src/features/mindmap/node/node_center/NodeCenter.tsx
@@ -16,11 +16,11 @@ export default function NodeCenter({ username = "", className, ...rest }: Props)
             onMouseLeave={() => setIsHover(false)}
             {...rest}
         >
-            {isHover && <AddNode color="violet" />}
+            {isHover && <AddNode color="violet" direction="left" />}
             <div className="cursor-pointer w-40 bg-primary rounded-full h-40 flex items-center justify-center text-white typo-body-16-semibold px-3 whitespace-pre-line">
                 {label}
             </div>
-            {isHover && <AddNode color="violet" />}
+            {isHover && <AddNode color="violet" direction="right" />}
         </div>
     );
 }


### PR DESCRIPTION
close #90 

# 목적
헤드 노드인 node_center 컴포넌트를 구현합니다.

# 작업 내용
### ➊ 센터 노드 hover 시 양쪽에 AddNode 보이기

### ❷ AddNode 내부 direction props 전달
- direction variant 적용으로 rotate
- AddNode > AddNodeArrow 에 button 이 중첩으로 있어서 AddNode를 div로 변경 후, AddNodeButton -> AddNode로 이름 변경

### ❸ username 포함 이름 설정
- 중간에 한 줄 띄어서 2줄로 보이게 함

# 결과

https://github.com/user-attachments/assets/3592a3d5-f119-4a2c-862f-5b559a9a8775

# 사용방법
```
<NodeCenter username="박은서" />
```

# 리뷰해줬으면 좋겠는 부분
헤드 노드가 무조건 violet 색이라 상수화로 violet으로 하드 코딩했습니다. (피그마를 봐도 기본 헤드노드 색은 violet이길래)

node 컴포넌트 추후 만들면서 리팩토링 예정..