### PR TITLE
[BE] 다대다 매핑 테이블 명 변경

### DIFF
--- a/backend/api/src/main/java/com/yat2/episode/diagnosis/DiagnosisWeakness.java
+++ b/backend/api/src/main/java/com/yat2/episode/diagnosis/DiagnosisWeakness.java
@@ -8,8 +8,9 @@ import lombok.Setter;
 @Entity
 @Getter
 @Setter
-@Table(name = "diagnosis_item")
-public class DiagnosisItem {
+@Table(name = "diagnosis_weakness")
+public class DiagnosisWeakness {
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Integer id;

--- a/backend/api/src/main/resources/db/migration/V4__alter_nm_table_names.sql
+++ b/backend/api/src/main/resources/db/migration/V4__alter_nm_table_names.sql
@@ -1,4 +1,3 @@
-
 ALTER TABLE `user2mindmap` DROP FOREIGN KEY `2mindmap`;
 ALTER TABLE `user2mindmap` DROP FOREIGN KEY `2user`;
 
@@ -9,33 +8,33 @@ ALTER TABLE `mindmap_participant` RENAME INDEX `2user_idx` TO `idx_participant_u
 
 ALTER TABLE `mindmap_participant`
     ADD CONSTRAINT `fk_participant_mindmap`
-    FOREIGN KEY (`mindmap_id`) REFERENCES `mindmap` (`id`)
-    ON DELETE CASCADE
-    ON UPDATE CASCADE;
+        FOREIGN KEY (`mindmap_id`) REFERENCES `mindmap` (`id`)
+            ON DELETE CASCADE
+            ON UPDATE CASCADE;
 
 ALTER TABLE `mindmap_participant`
     ADD CONSTRAINT `fk_participant_user`
-    FOREIGN KEY (`user_id`) REFERENCES `users` (`kakao_id`)
-    ON DELETE CASCADE
-    ON UPDATE CASCADE;
+        FOREIGN KEY (`user_id`) REFERENCES `users` (`kakao_id`)
+            ON DELETE CASCADE
+            ON UPDATE CASCADE;
 
 
 ALTER TABLE `diagnosis2question` DROP FOREIGN KEY `2question`;
 ALTER TABLE `diagnosis2question` DROP FOREIGN KEY `diagnosis_result`;
 
-ALTER TABLE `diagnosis2question` RENAME TO `diagnosis_item`;
+ALTER TABLE `diagnosis2question` RENAME TO `diagnosis_weakness`;
 
-ALTER TABLE `diagnosis_item` RENAME INDEX `2question_idx` TO `idx_item_question`;
-ALTER TABLE `diagnosis_item` RENAME INDEX `2diagnosis_result_idx` TO `idx_item_result`;
+ALTER TABLE `diagnosis_weakness` RENAME INDEX `2question_idx` TO `idx_weakness_question`;
+ALTER TABLE `diagnosis_weakness` RENAME INDEX `2diagnosis_result_idx` TO `idx_weakness_result`;
 
-ALTER TABLE `diagnosis_item`
-    ADD CONSTRAINT `fk_item_question`
-    FOREIGN KEY (`question_id`) REFERENCES `question` (`id`)
-    ON DELETE CASCADE
-    ON UPDATE CASCADE;
+ALTER TABLE `diagnosis_weakness`
+    ADD CONSTRAINT `fk_weakness_question`
+        FOREIGN KEY (`question_id`) REFERENCES `question` (`id`)
+            ON DELETE CASCADE
+            ON UPDATE CASCADE;
 
-ALTER TABLE `diagnosis_item`
-    ADD CONSTRAINT `fk_item_result`
-    FOREIGN KEY (`diagnosis_result_id`) REFERENCES `diagnosis_result` (`id`)
-    ON DELETE CASCADE
-    ON UPDATE CASCADE;
+ALTER TABLE `diagnosis_weakness`
+    ADD CONSTRAINT `fk_weakness_result`
+        FOREIGN KEY (`diagnosis_result_id`) REFERENCES `diagnosis_result` (`id`)
+            ON DELETE CASCADE
+            ON UPDATE CASCADE;


### PR DESCRIPTION
close #168

# 목적
기존의 로직적인 테이블 명을 관계성을 살린 테이블 명으로 변경함으로써 다대다 테이블 사이의 관계를 더 명확히 합니다.

# 작업 내용
- user2mindmap 테이블을 mindmap_participant로 변경합니다.
- diagnosis2question 테이블을 diagnosis_item으로 변경합니다.

- flyway 마이그레이션 파일로 변경합니다.
- JPA 매핑 값을 변경합니다.

# 결과
<img width="440" height="443" alt="image" src="https://github.com/user-attachments/assets/32e30589-382e-4287-bb0e-ce1f6fe2a5e7" />


