### PR TITLE
[FE] 라이브러리는 타입을 신경쓰지 않는 옵션 추가

### DIFF
--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -4,6 +4,7 @@
         "moduleResolution": "bundler",
         "jsx": "react-jsx",
         "baseUrl": "./src",
+        "skipLibCheck": true,
         "paths": {
             "@shared/*": ["shared/*"],
             "@utils/*": ["utils/*"],


### PR DESCRIPTION
Closes #199

# 목적
라이브러리 타입때문에 빌드가 안되는 문제를 해결합니다.
