### PR TITLE
[BE] OAuth 흐름 중 에러는 redirect 하며 쿼리파라미터로 응답

### DIFF
--- a/backend/api/src/main/java/com/yat2/episode/auth/AuthController.java
+++ b/backend/api/src/main/java/com/yat2/episode/auth/AuthController.java
@@ -70,6 +70,7 @@ public class AuthController {
                     .header(HttpHeaders.LOCATION, redirect)
                     .build();
         } catch (Exception e) {
+            safeInvalidate(session);
             return redirectToFrontWithError(ErrorCode.INTERNAL_ERROR);
         }
     }
@@ -98,8 +99,6 @@ public class AuthController {
                 throw new CustomException(ErrorCode.INVALID_OAUTH_STATE);
             }
 
-            safeInvalidate(session);
-
             IssuedTokens tokens = authService.handleKakaoCallback(code);
 
             ResponseCookie accessCookie = authCookieFactory.access(tokens.accessToken());
@@ -112,11 +111,11 @@ public class AuthController {
                     .build();
 
         } catch (CustomException e) {
-            safeInvalidate(session);
             return redirectToFrontWithError(e.getErrorCode());
         } catch (Exception e) {
-            safeInvalidate(session);
             return redirectToFrontWithError(ErrorCode.INTERNAL_ERROR);
+        } finally {
+            safeInvalidate(session);
         }
     }
 

--- a/backend/api/src/main/java/com/yat2/episode/auth/AuthController.java
+++ b/backend/api/src/main/java/com/yat2/episode/auth/AuthController.java
@@ -1,10 +1,10 @@
 package com.yat2.episode.auth;
 
+import com.yat2.episode.auth.cookie.AuthCookieFactory;
 import com.yat2.episode.auth.jwt.IssuedTokens;
 import com.yat2.episode.auth.oauth.KakaoProperties;
 import com.yat2.episode.auth.oauth.OAuthUtil;
 import com.yat2.episode.auth.refresh.RefreshTokenService;
-import com.yat2.episode.auth.cookie.AuthCookieFactory;
 import com.yat2.episode.auth.security.Public;
 import com.yat2.episode.global.exception.CustomException;
 import com.yat2.episode.global.exception.ErrorCode;
@@ -15,7 +15,6 @@ import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
@@ -35,6 +34,7 @@ public class AuthController {
 
     @Value("${auth.redirect}")
     private String oauthRedirect;
+
     private final KakaoProperties kakaoProperties;
     private final AuthService authService;
     private final AuthCookieFactory authCookieFactory;
@@ -49,25 +49,29 @@ public class AuthController {
             @ApiResponse(responseCode = "302", description = "카카오 인가 페이지로 Redirect")
     })
     @ApiErrorCodes(ErrorCode.INTERNAL_ERROR)
-    public ResponseEntity<Void> loginWithKakao(HttpSession session, HttpServletRequest request) {
-        String clientId = kakaoProperties.getClientId();
-        String redirectUri = kakaoProperties.getRedirectUri();
-        String authUrl = kakaoProperties.authUrl();
+    public ResponseEntity<Void> loginWithKakao(HttpSession session) {
+        try {
+            String clientId = kakaoProperties.getClientId();
+            String redirectUri = kakaoProperties.getRedirectUri();
+            String authUrl = kakaoProperties.authUrl();
 
-        String state = OAuthUtil.generateState();
-        session.setAttribute(SESSION_STATE, state);
+            String state = OAuthUtil.generateState();
+            session.setAttribute(SESSION_STATE, state);
 
-        String redirect = UriComponentsBuilder.fromUriString(authUrl)
-                .queryParam("response_type", "code")
-                .queryParam("client_id", clientId)
-                .queryParam("redirect_uri", redirectUri)
-                .queryParam("state", state)
-                .build()
-                .toUriString();
+            String redirect = UriComponentsBuilder.fromUriString(authUrl)
+                    .queryParam("response_type", "code")
+                    .queryParam("client_id", clientId)
+                    .queryParam("redirect_uri", redirectUri)
+                    .queryParam("state", state)
+                    .build()
+                    .toUriString();
 
-        return ResponseEntity.status(302)
-                .header(HttpHeaders.LOCATION, redirect)
-                .build();
+            return ResponseEntity.status(302)
+                    .header(HttpHeaders.LOCATION, redirect)
+                    .build();
+        } catch (Exception e) {
+            return redirectToFrontWithError(ErrorCode.INTERNAL_ERROR);
+        }
     }
 
     @GetMapping("/callback")
@@ -81,30 +85,39 @@ public class AuthController {
     @ApiErrorCodes({
             ErrorCode.INVALID_OAUTH_STATE,
             ErrorCode.INVALID_OAUTH_ID_TOKEN,
-            ErrorCode.INTERNAL_ERROR})
+            ErrorCode.INTERNAL_ERROR
+    })
     public ResponseEntity<Void> kakaoCallback(
             HttpSession session,
             @RequestParam("code") String code,
             @RequestParam("state") String state
     ) {
-        String sessionState = (String) session.getAttribute(SESSION_STATE);
+        try {
+            String sessionState = (String) session.getAttribute(SESSION_STATE);
+            if (sessionState == null || !sessionState.equals(state)) {
+                throw new CustomException(ErrorCode.INVALID_OAUTH_STATE);
+            }
 
-        if (sessionState == null || !sessionState.equals(state)) {
-            throw new CustomException(ErrorCode.INVALID_OAUTH_STATE);
+            safeInvalidate(session);
+
+            IssuedTokens tokens = authService.handleKakaoCallback(code);
+
+            ResponseCookie accessCookie = authCookieFactory.access(tokens.accessToken());
+            ResponseCookie refreshCookie = authCookieFactory.refresh(tokens.refreshToken());
+
+            return ResponseEntity.status(302)
+                    .header(HttpHeaders.LOCATION, oauthRedirect)
+                    .header(HttpHeaders.SET_COOKIE, accessCookie.toString())
+                    .header(HttpHeaders.SET_COOKIE, refreshCookie.toString())
+                    .build();
+
+        } catch (CustomException e) {
+            safeInvalidate(session);
+            return redirectToFrontWithError(e.getErrorCode());
+        } catch (Exception e) {
+            safeInvalidate(session);
+            return redirectToFrontWithError(ErrorCode.INTERNAL_ERROR);
         }
-
-        session.invalidate();
-
-        IssuedTokens tokens = authService.handleKakaoCallback(code);
-
-        ResponseCookie accessCookie = authCookieFactory.access(tokens.accessToken());
-        ResponseCookie refreshCookie = authCookieFactory.refresh(tokens.refreshToken());
-
-        return ResponseEntity.status(302)
-                .header(HttpHeaders.LOCATION, oauthRedirect)
-                .header(HttpHeaders.SET_COOKIE, accessCookie.toString())
-                .header(HttpHeaders.SET_COOKIE, refreshCookie.toString())
-                .build();
     }
 
     @PostMapping("/refresh")
@@ -162,5 +175,22 @@ public class AuthController {
                 .header(HttpHeaders.SET_COOKIE, expiredAccess.toString())
                 .header(HttpHeaders.SET_COOKIE, expiredRefresh.toString())
                 .build();
+    }
+
+    private ResponseEntity<Void> redirectToFrontWithError(ErrorCode errorCode) {
+        String redirect = UriComponentsBuilder.fromUriString(oauthRedirect)
+                .queryParam("error_code", errorCode.getCode())
+                .build()
+                .toUriString();
+
+        return ResponseEntity.status(302)
+                .header(HttpHeaders.LOCATION, redirect)
+                .build();
+    }
+
+    private void safeInvalidate(HttpSession session) {
+        try {
+            session.invalidate();
+        } catch (Exception ignored) {}
     }
 }

--- a/backend/api/src/main/java/com/yat2/episode/global/exception/GlobalExceptionHandler.java
+++ b/backend/api/src/main/java/com/yat2/episode/global/exception/GlobalExceptionHandler.java
@@ -4,6 +4,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.servlet.NoHandlerFoundException;
@@ -38,5 +39,11 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ErrorResponse> handleNoHandler(HttpRequestMethodNotSupportedException e) {
         return ResponseEntity.status(HttpStatus.METHOD_NOT_ALLOWED)
                 .body(ErrorResponse.of(ErrorCode.METHOD_NOT_ALLOWED, ErrorCode.METHOD_NOT_ALLOWED.getMessage()));
+    }
+
+    @ExceptionHandler(MissingServletRequestParameterException.class)
+    public ResponseEntity<ErrorResponse> handleMissingServletRequestParameterException(MissingServletRequestParameterException e) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(ErrorResponse.of(ErrorCode.INVALID_REQUEST, ErrorCode.INVALID_REQUEST.getMessage()));
     }
 }


### PR DESCRIPTION
Closes #252 

# 목적
뷰 제어권이 백엔드에 있는 상황에서
에러 응답을 주면 프론트에서 에러 핸들링이 불가하므로...
에러 응답을 쿼리 파라미터로 넣어서 redirect 시키게 합니다.

# 작업 내용
- 에러 응답을 redirect
- 잘못된 파라미터의 경우 400 에러 내기

# 결과
<img width="407" height="45" alt="image" src="https://github.com/user-attachments/assets/779e5d72-fd56-4177-a43c-5d451bcc667a" />


# (optional) 변경 전/후

# (optional) 사용방법

# (optional) 리뷰해줬으면 좋겠는 부분

# (optional) 기타
