### PR TITLE
[BE] 마인드맵 제목 수정

### DIFF
--- a/backend/api/src/main/java/com/yat2/episode/global/exception/CustomException.java
+++ b/backend/api/src/main/java/com/yat2/episode/global/exception/CustomException.java
@@ -11,4 +11,9 @@ public class CustomException extends RuntimeException {
         super(errorCode.getMessage());
         this.errorCode = errorCode;
     }
+
+    public CustomException(ErrorCode errorCode, String message) {
+        super(message);
+        this.errorCode = errorCode;
+    }
 }

--- a/backend/api/src/main/java/com/yat2/episode/global/exception/GlobalExceptionHandler.java
+++ b/backend/api/src/main/java/com/yat2/episode/global/exception/GlobalExceptionHandler.java
@@ -10,6 +10,8 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.servlet.NoHandlerFoundException;
 
+import java.util.stream.Collectors;
+
 @Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
@@ -47,7 +49,10 @@ public class GlobalExceptionHandler {
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
-    public void handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
-        throw new CustomException(ErrorCode.INVALID_REQUEST, e.getMessage());
+    public ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
+        String errorMessage = e.getBindingResult().getFieldErrors().stream()
+                .map(error -> error.getField() + ": " + error.getDefaultMessage()).collect(Collectors.joining(", "));
+        return ResponseEntity.status(ErrorCode.INVALID_REQUEST.getHttpStatus())
+                .body(ErrorResponse.of(ErrorCode.INVALID_REQUEST, errorMessage));
     }
 }

--- a/backend/api/src/main/java/com/yat2/episode/global/exception/GlobalExceptionHandler.java
+++ b/backend/api/src/main/java/com/yat2/episode/global/exception/GlobalExceptionHandler.java
@@ -1,6 +1,7 @@
 package com.yat2.episode.global.exception;
 
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.support.DefaultMessageSourceResolvable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
@@ -50,8 +51,9 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
-        String errorMessage = e.getBindingResult().getFieldErrors().stream()
-                .map(error -> error.getField() + ": " + error.getDefaultMessage()).collect(Collectors.joining(", "));
+        String errorMessage =
+                e.getBindingResult().getAllErrors().stream().map(DefaultMessageSourceResolvable::getDefaultMessage)
+                        .collect(Collectors.joining(", "));
         return ResponseEntity.status(ErrorCode.INVALID_REQUEST.getHttpStatus())
                 .body(ErrorResponse.of(ErrorCode.INVALID_REQUEST, errorMessage));
     }

--- a/backend/api/src/main/java/com/yat2/episode/global/exception/GlobalExceptionHandler.java
+++ b/backend/api/src/main/java/com/yat2/episode/global/exception/GlobalExceptionHandler.java
@@ -4,6 +4,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -43,5 +44,10 @@ public class GlobalExceptionHandler {
             MissingServletRequestParameterException e) {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
                 .body(ErrorResponse.of(ErrorCode.INVALID_REQUEST, ErrorCode.INVALID_REQUEST.getMessage()));
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public void handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
+        throw new CustomException(ErrorCode.INVALID_REQUEST, e.getMessage());
     }
 }

--- a/backend/api/src/main/java/com/yat2/episode/mindmap/Mindmap.java
+++ b/backend/api/src/main/java/com/yat2/episode/mindmap/Mindmap.java
@@ -34,6 +34,10 @@ public class Mindmap {
     @Column(name = "is_shared", nullable = false)
     private boolean shared;
 
+    public void updateName(String name) {
+        this.name = name;
+    }
+
     public Mindmap(String name, boolean shared) {
         this.name = name;
         this.shared = shared;

--- a/backend/api/src/main/java/com/yat2/episode/mindmap/MindmapController.java
+++ b/backend/api/src/main/java/com/yat2/episode/mindmap/MindmapController.java
@@ -162,6 +162,18 @@ public class MindmapController {
         return ResponseEntity.ok(updatedMindmap);
     }
 
+    @Operation(summary = "마인드맵 이름 변경", description = "마인드맵의 이름을 변경합니다. 팀 마인드맵 또한 모든 사용자에게 반영되는 수정 사항입니다.")
+    @ApiResponses({ @ApiResponse(responseCode = "200", description = "업데이트 성공",
+            content = @Content(schema = @Schema(implementation = MindmapDataDto.class))) })
+    @AuthRequiredErrors
+    @ApiErrorCodes({ ErrorCode.USER_NOT_FOUND, ErrorCode.INTERNAL_ERROR, ErrorCode.MINDMAP_NOT_FOUND })
+    @PatchMapping("/{mindmapId}/name")
+    public ResponseEntity<MindmapDataDto> updateName(@RequestAttribute(USER_ID) long userId,
+                                                     @PathVariable String mindmapId, @RequestParam String name) {
+        MindmapDataDto updatedMindmap = mindmapService.updateName(userId, mindmapId, name);
+        return ResponseEntity.ok(updatedMindmap);
+    }
+
     public enum MindmapVisibility {
         ALL, PRIVATE, PUBLIC
     }

--- a/backend/api/src/main/java/com/yat2/episode/mindmap/MindmapController.java
+++ b/backend/api/src/main/java/com/yat2/episode/mindmap/MindmapController.java
@@ -7,6 +7,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CookieValue;
@@ -33,6 +34,7 @@ import com.yat2.episode.mindmap.dto.MindmapArgsReqDto;
 import com.yat2.episode.mindmap.dto.MindmapCreatedWithUrlDto;
 import com.yat2.episode.mindmap.dto.MindmapDataDto;
 import com.yat2.episode.mindmap.dto.MindmapIdentityDto;
+import com.yat2.episode.mindmap.dto.MindmapNameUpdateReqDto;
 
 import static com.yat2.episode.global.constant.RequestAttrs.USER_ID;
 
@@ -169,8 +171,9 @@ public class MindmapController {
     @ApiErrorCodes({ ErrorCode.USER_NOT_FOUND, ErrorCode.INTERNAL_ERROR, ErrorCode.MINDMAP_NOT_FOUND })
     @PatchMapping("/{mindmapId}/name")
     public ResponseEntity<MindmapDataDto> updateName(@RequestAttribute(USER_ID) long userId,
-                                                     @PathVariable String mindmapId, @RequestParam String name) {
-        MindmapDataDto updatedMindmap = mindmapService.updateName(userId, mindmapId, name);
+                                                     @PathVariable String mindmapId,
+                                                     @Valid @RequestBody MindmapNameUpdateReqDto request) {
+        MindmapDataDto updatedMindmap = mindmapService.updateName(userId, mindmapId, request.name());
         return ResponseEntity.ok(updatedMindmap);
     }
 

--- a/backend/api/src/main/java/com/yat2/episode/mindmap/MindmapService.java
+++ b/backend/api/src/main/java/com/yat2/episode/mindmap/MindmapService.java
@@ -170,6 +170,14 @@ public class MindmapService {
         return MindmapDataDto.of(participant);
     }
 
+    @Transactional
+    public MindmapDataDto updateName(long userId, String mindmapId, String name) {
+        MindmapParticipant participant = findParticipantOrThrow(mindmapId, userId);
+        participant.getMindmap().updateName(name);
+
+        return MindmapDataDto.of(participant);
+    }
+
     private MindmapParticipant findParticipantOrThrow(String mindmapId, long userId) {
         return mindmapParticipantRepository.findByMindmapIdAndUserId(getUUID(mindmapId), userId)
                 .orElseThrow(() -> new CustomException(ErrorCode.MINDMAP_NOT_FOUND));

--- a/backend/api/src/main/java/com/yat2/episode/mindmap/dto/MindmapNameUpdateReqDto.java
+++ b/backend/api/src/main/java/com/yat2/episode/mindmap/dto/MindmapNameUpdateReqDto.java
@@ -1,0 +1,7 @@
+package com.yat2.episode.mindmap.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record MindmapNameUpdateReqDto(
+        @NotBlank(message = "이름은 공백일 수 없습니다.") @Size(max = 43, message = "이름은 43자 이내여야 합니다.") String name) {}


### PR DESCRIPTION
Closes #269

# 목적
개인/팀 마인드맵의 제목 수정 기능 개발

# 작업 내용
- 개인/팀 마인드맵의 제목 수정 api를 개발합니다.
- 입력에 대한 체크를 valid 어노테이션으로 진행합니다.
- valid 어노테이션에 대해 작성된 부분을 기존 custom error 값처럼 제공할 수 있도록 global exception 핸들러에 추가합니다.
  - error code는 통일하되 내부 메세지로 알려주도록 => 프론트 단과 협의 완료

# 결과

<img width="1133" height="461" alt="스크린샷 2026-02-03 오후 3 22 50" src="https://github.com/user-attachments/assets/3218e7bf-7b89-493f-810a-4ec059155ec6" />

<img width="1070" height="484" alt="image" src="https://github.com/user-attachments/assets/c9647343-c800-46f6-b54a-403454cdcfe0" />


# 이후 고민해야 할 내용
팀 마인드맵의 경우, 참여자 모두가 제목 수정이 가능하며 수정 시에도 모두에게 반영이 되어야 합니다.
웹소켓 연결로 내려보내는 방식, 프론트 단에서 주기적으로 조회 재요청 보내는 방식과 같이 어떤 식으로 구현하면 좋을지 논의가 필요한 것 같습니다.
