### PR TITLE
[BE] 배포 실패 시 자동 롤백

### DIFF
--- a/.github/workflows/cd-stage.yml
+++ b/.github/workflows/cd-stage.yml
@@ -10,6 +10,7 @@ on:
     paths:
       - "backend/**"
       - "infra/stage/**"
+      - ".github/workflows/cd-stage.yml"
 
 jobs:
   deploy:
@@ -68,11 +69,23 @@ jobs:
           chmod 600 ~/.ssh/id_rsa
           ssh-keyscan -H ${{ secrets.STAGE_EC2_HOST }} >> ~/.ssh/known_hosts
 
+      - name: Backup infra files
+        run: |
+          ssh ${{ secrets.STAGE_EC2_USER }}@${{ secrets.STAGE_EC2_HOST }} << 'EOF'
+            set -e
+            cd /home/${{ secrets.STAGE_EC2_USER }}/app
+          
+            [ -f docker-compose.yml ] && cp docker-compose.yml .docker-compose.prev.yml || echo "No docker-compose to backup"
+            [ -f Caddyfile ] && cp Caddyfile .Caddyfile.prev || echo "No Caddyfile to backup"
+          EOF
+
       - name: Sync infra files to server
         working-directory: .
         run: |
           rsync -avz --delete \
             --exclude='.env' \
+            --exclude='.Caddyfile.prev' \
+            --exclude='.docker-compose.prev.yml' \
             infra/stage/ \
             ${{ secrets.STAGE_EC2_USER }}@${{ secrets.STAGE_EC2_HOST }}:/home/${{ secrets.STAGE_EC2_USER }}/app/
 
@@ -81,16 +94,26 @@ jobs:
           ssh ${{ secrets.STAGE_EC2_USER }}@${{ secrets.STAGE_EC2_HOST }} << 'EOF'
             set -e
             cd /home/${{ secrets.STAGE_EC2_USER }}/app
+          
+            CURRENT_ID=$(docker inspect episode-api \
+              --format '{{.Image}}' 2>/dev/null || true)
+          
+            if [ ! -z "$CURRENT_ID" ]; then
+              echo "$CURRENT_ID" > .prev_image_id
+              echo "Saved previous image ID: $CURRENT_ID"
+            else
+              rm -f .prev_image_id || true
+            fi
 
             docker compose pull
             docker compose up -d
             docker compose exec -T caddy caddy validate --config /etc/caddy/Caddyfile
             docker compose exec -T caddy caddy reload --config /etc/caddy/Caddyfile
 
-            docker image prune -f
           EOF
 
       - name: Health check (Stage)
+        id: health_check
         run: |
           set -e
           URL="https://stage.episode.io.kr/actuator/health"
@@ -113,3 +136,36 @@ jobs:
 
           echo "Health check failed"
           exit 1
+
+      - name: Rollback on failure
+        if: failure() && steps.health_check.outcome == 'failure'
+        run: |
+          echo "Health check failed. Rolling back..."
+          ssh ${{ secrets.STAGE_EC2_USER }}@${{ secrets.STAGE_EC2_HOST }} << 'EOF'
+            cd /home/${{ secrets.STAGE_EC2_USER }}/app
+          
+            [ -f .docker-compose.prev.yml ] && mv .docker-compose.prev.yml docker-compose.yml || echo "No previous docker-compose found"
+            [ -f .Caddyfile.prev ] && mv .Caddyfile.prev Caddyfile || echo "No previous Caddyfile found"
+          
+            if [ ! -f .prev_image_id ]; then
+              echo "No previous image ID found."
+              exit 1
+            fi
+          
+            TARGET_ID=$(cat .prev_image_id)
+          
+            echo "Restoring Image ID: $TARGET_ID"
+            docker tag $TARGET_ID ghcr.io/${{ github.repository_owner }}/episode-api:stage
+          
+            docker compose up -d
+            docker compose exec -T caddy caddy reload --config /etc/caddy/Caddyfile || true
+          
+            echo "Rollback completed."
+          EOF
+
+      - name: Cleanup Images
+        if: always()
+        run: |
+          ssh ${{ secrets.STAGE_EC2_USER }}@${{ secrets.STAGE_EC2_HOST }} << 'EOF'
+            docker image prune -f
+          EOF

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -10,6 +10,7 @@ on:
     paths:
       - "backend/**"
       - "infra/prod/**"
+      - ".github/workflows/cd.yml"
 
 jobs:
   deploy:
@@ -68,11 +69,23 @@ jobs:
           chmod 600 ~/.ssh/id_rsa
           ssh-keyscan -H ${{ secrets.EC2_HOST }} >> ~/.ssh/known_hosts
 
+      - name: Backup infra files
+        run: |
+          ssh ${{ secrets.EC2_USER }}@${{ secrets.EC2_HOST }} << 'EOF'
+            set -e
+            cd /home/${{ secrets.EC2_USER }}/app
+          
+            [ -f docker-compose.yml ] && cp docker-compose.yml .docker-compose.prev.yml || echo "No docker-compose to backup"
+            [ -f Caddyfile ] && cp Caddyfile .Caddyfile.prev || echo "No Caddyfile to backup"
+          EOF
+
       - name: Sync infra files to server
         working-directory: .
         run: |
           rsync -avz --delete \
             --exclude='.env' \
+            --exclude='.Caddyfile.prev' \
+            --exclude='.docker-compose.prev.yml' \
             infra/prod/ \
             ${{ secrets.EC2_USER }}@${{ secrets.EC2_HOST }}:/home/${{ secrets.EC2_USER }}/app/
 
@@ -82,15 +95,25 @@ jobs:
             set -e
             cd /home/${{ secrets.EC2_USER }}/app
 
+            CURRENT_ID=$(docker inspect episode-api \
+              --format '{{.Image}}' 2>/dev/null || true)
+
+            if [ ! -z "$CURRENT_ID" ]; then
+              echo "$CURRENT_ID" > .prev_image_id
+              echo "Saved previous image ID: $CURRENT_ID"
+            else
+              rm -f .prev_image_id || true
+            fi
+
             docker compose pull
             docker compose up -d
             docker compose exec -T caddy caddy validate --config /etc/caddy/Caddyfile
             docker compose exec -T caddy caddy reload --config /etc/caddy/Caddyfile
 
-            docker image prune -f
           EOF
 
       - name: Health check
+        id: health_check
         run: |
           set -e
           URL="https://api.episode.io.kr/actuator/health"
@@ -113,3 +136,36 @@ jobs:
 
           echo "Health check failed"
           exit 1
+
+      - name: Rollback on failure
+        if: failure() && steps.health_check.outcome == 'failure'
+        run: |
+          echo "Health check failed. Rolling back..."
+          ssh ${{ secrets.EC2_USER }}@${{ secrets.EC2_HOST }} << 'EOF'
+            cd /home/${{ secrets.EC2_USER }}/app
+
+            [ -f .docker-compose.prev.yml ] && mv .docker-compose.prev.yml docker-compose.yml || echo "No previous docker-compose found"
+            [ -f .Caddyfile.prev ] && mv .Caddyfile.prev Caddyfile || echo "No previous Caddyfile found"
+
+            if [ ! -f .prev_image_id ]; then
+              echo "No previous image ID found."
+              exit 1
+            fi
+
+            TARGET_ID=$(cat .prev_image_id)
+
+            echo "Restoring Image ID: $TARGET_ID"
+            docker tag $TARGET_ID ghcr.io/${{ github.repository_owner }}/episode-api:latest
+
+            docker compose up -d
+            docker compose exec -T caddy caddy reload --config /etc/caddy/Caddyfile || true
+
+            echo "Rollback completed."
+          EOF
+
+      - name: Cleanup Images
+        if: always()
+        run: |
+          ssh ${{ secrets.EC2_USER }}@${{ secrets.EC2_HOST }} << 'EOF'
+            docker image prune -f
+          EOF


### PR DESCRIPTION
Closes #266 

# 목적
배포가 실패했을때, 자동으로 이전 버전의 이미지와 인프라 파일로 롤백해 가용성 확보

# 작업 내용
- 워크플로우에서 인프라 파일/실행중인 이미지 id 백업
- 헬스체크 실패시 백업해둔 정보를 이용해 롤백
