### PR TITLE
[BE] unit 테스트 생성

### DIFF
--- a/backend/api/src/test/java/com/yat2/episode/competency/CompetencyTypeServiceTest.java
+++ b/backend/api/src/test/java/com/yat2/episode/competency/CompetencyTypeServiceTest.java
@@ -35,8 +35,8 @@ class CompetencyTypeServiceTest {
         List<DetailCompetencyTypeDto> result = competencyTypeService.getAllData();
 
         assertThat(result).hasSize(2);
-        assertThat(result.get(0).getCompetencyType()).isEqualTo("의사소통");
-        assertThat(result.get(1).getCompetencyType()).isEqualTo("논리적 사고");
+        assertThat(result).extracting(DetailCompetencyTypeDto::getCompetencyType)
+                .containsExactlyInAnyOrder("의사소통", "논리적 사고");
     }
 
     @Test

--- a/backend/api/src/test/java/com/yat2/episode/competency/CompetencyTypeServiceTest.java
+++ b/backend/api/src/test/java/com/yat2/episode/competency/CompetencyTypeServiceTest.java
@@ -1,0 +1,64 @@
+package com.yat2.episode.competency;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.List;
+
+import com.yat2.episode.competency.dto.DetailCompetencyTypeDto;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class CompetencyTypeServiceTest {
+
+    @Mock
+    private CompetencyTypeRepository competencyTypeRepository;
+
+    @InjectMocks
+    private CompetencyTypeService competencyTypeService;
+
+    @Test
+    @DisplayName("전체 역량 타입 목록을 조회하여 DTO로 변환한다")
+    void getAllData_Success() {
+        CompetencyType type1 = createCompetencyType(1, "의사소통", CompetencyType.Category.협업_커뮤니케이션_역량);
+        CompetencyType type2 = createCompetencyType(2, "논리적 사고", CompetencyType.Category.문제해결_사고_역량);
+
+        given(competencyTypeRepository.findAll()).willReturn(List.of(type1, type2));
+
+        List<DetailCompetencyTypeDto> result = competencyTypeService.getAllData();
+
+        assertThat(result).hasSize(2);
+        assertThat(result.get(0).getCompetencyType()).isEqualTo("의사소통");
+        assertThat(result.get(1).getCompetencyType()).isEqualTo("논리적 사고");
+    }
+
+    @Test
+    @DisplayName("마인드맵 ID로 조회 시 해당 마인드맵의 역량 타입들만 반환한다")
+    void getCompetencyTypesInMindmap_Success() {
+        String mindmapId = "test-uuid-string";
+        CompetencyType type = createCompetencyType(10, "성장 가능성", CompetencyType.Category.실행_성장_역량);
+
+        given(competencyTypeRepository.findByMindmapId(mindmapId)).willReturn(List.of(type));
+
+        List<DetailCompetencyTypeDto> result = competencyTypeService.getCompetencyTypesInMindmap(mindmapId);
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getId()).isEqualTo(10);
+        assertThat(result.get(0).getCompetencyType()).isEqualTo("성장 가능성");
+    }
+
+    private CompetencyType createCompetencyType(Integer id, String typeName, CompetencyType.Category category) {
+        CompetencyType ct = new CompetencyType();
+        ReflectionTestUtils.setField(ct, "id", id);
+        ReflectionTestUtils.setField(ct, "typeName", typeName);
+        ReflectionTestUtils.setField(ct, "category", category);
+        return ct;
+    }
+}

--- a/backend/api/src/test/java/com/yat2/episode/job/JobServiceTest.java
+++ b/backend/api/src/test/java/com/yat2/episode/job/JobServiceTest.java
@@ -1,0 +1,75 @@
+package com.yat2.episode.job;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import com.yat2.episode.job.dto.OccupationWithJobsResponse;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class JobServiceTest {
+
+    @Mock
+    private JobRepository jobRepository;
+
+    @InjectMocks
+    private JobService jobService;
+
+    @Test
+    @DisplayName("직군이 비어있을 경우 빈 리스트를 반환한다")
+    void getOccupationsWithJobs_Empty() {
+        given(jobRepository.findAllWithOccupation()).willReturn(List.of());
+
+        List<OccupationWithJobsResponse> result = jobService.getOccupationsWithJobs();
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("서로 다른 직군의 직무들을 조회하면 직군별로 그룹화되어 반환된다")
+    void getOccupationsWithJobs_GroupingSuccess() {
+        Occupation occ1 = createOccupation(1, "개발");
+        Occupation occ2 = createOccupation(2, "디자인");
+
+        Job job1 = createJob(101, "백엔드", occ1);
+        Job job2 = createJob(102, "프론트엔드", occ1);
+        Job job3 = createJob(201, "UI/UX", occ2);
+
+        given(jobRepository.findAllWithOccupation()).willReturn(List.of(job1, job2, job3));
+
+        List<OccupationWithJobsResponse> result = jobService.getOccupationsWithJobs();
+
+        assertThat(result).hasSize(2);
+
+        assertThat(result.get(0).occupationName()).isEqualTo("개발");
+        assertThat(result.get(0).jobs()).hasSize(2);
+        assertThat(result.get(0).jobs().get(0).name()).isEqualTo("백엔드");
+
+        assertThat(result.get(1).occupationName()).isEqualTo("디자인");
+        assertThat(result.get(1).jobs()).hasSize(1);
+        assertThat(result.get(1).jobs().get(0).name()).isEqualTo("UI/UX");
+    }
+
+    private Occupation createOccupation(Integer id, String name) {
+        Occupation o = new Occupation();
+        o.setId(id);
+        o.setName(name);
+        return o;
+    }
+
+    private Job createJob(Integer id, String name, Occupation occupation) {
+        Job j = new Job();
+        j.setId(id);
+        j.setName(name);
+        j.setOccupation(occupation);
+        return j;
+    }
+}

--- a/backend/api/src/test/java/com/yat2/episode/question/QuestionControllerTest.java
+++ b/backend/api/src/test/java/com/yat2/episode/question/QuestionControllerTest.java
@@ -72,10 +72,6 @@ class QuestionServiceTest {
 
         List<CategoryGroupResponseDto> result = questionService.getQuestionSetByUserId(userId);
 
-        result.forEach(group -> {
-            group.questions().forEach(q -> System.out.println("  - [" + q.id() + "] " + q.content()));
-        });
-
         assertThat(result).hasSize(2);
         assertThat(result.get(0).category()).isEqualTo(CompetencyType.Category.협업_커뮤니케이션_역량);
         assertThat(result.get(0).questions()).hasSize(2);

--- a/backend/api/src/test/java/com/yat2/episode/question/QuestionControllerTest.java
+++ b/backend/api/src/test/java/com/yat2/episode/question/QuestionControllerTest.java
@@ -1,0 +1,91 @@
+package com.yat2.episode.question;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.List;
+
+import com.yat2.episode.competency.CompetencyType;
+import com.yat2.episode.global.exception.CustomException;
+import com.yat2.episode.global.exception.ErrorCode;
+import com.yat2.episode.job.Job;
+import com.yat2.episode.question.dto.CategoryGroupResponseDto;
+import com.yat2.episode.user.User;
+import com.yat2.episode.user.UserService;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+@ExtendWith(MockitoExtension.class)
+class QuestionServiceTest {
+
+    @Mock
+    private QuestionRepository questionRepository;
+
+    @Mock
+    private UserService userService;
+
+    @InjectMocks
+    private QuestionService questionService;
+
+    @Test
+    @DisplayName("사용자의 직무가 설정되지 않은 경우 JOB_NOT_SELECTED 예외가 발생한다")
+    void getQuestionSet_Fail_JobNotSelected() {
+        long userId = 12345678L;
+        User userWithoutJob = User.newUser(userId, "테스트유저");
+
+        given(userService.getUserOrThrow(userId)).willReturn(userWithoutJob);
+
+        assertThatThrownBy(() -> questionService.getQuestionSetByUserId(userId)).isInstanceOf(CustomException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.JOB_NOT_SELECTED);
+    }
+
+    @Test
+    @DisplayName("직무에 맞는 문항들을 조회하여 카테고리별로 그룹화하여 반환한다")
+    void getQuestionSet_Success() {
+        long userId = 12345678L;
+        User user = User.newUser(userId, "테스트유저");
+
+        Job job = new Job();
+        ReflectionTestUtils.setField(job, "id", 10);
+        user.updateJob(job);
+
+        CompetencyType typeA = mock(CompetencyType.class);
+        given(typeA.getCategory()).willReturn(CompetencyType.Category.협업_커뮤니케이션_역량);
+
+        CompetencyType typeB = mock(CompetencyType.class);
+        given(typeB.getCategory()).willReturn(CompetencyType.Category.문제해결_사고_역량);
+
+        Question q1 = createQuestion(1, "질문1", typeA);
+        Question q2 = createQuestion(2, "질문2", typeA);
+        Question q3 = createQuestion(3, "질문3", typeB);
+
+        given(userService.getUserOrThrow(userId)).willReturn(user);
+        given(questionRepository.findAllWithCompetencyByJobId(10)).willReturn(List.of(q1, q2, q3));
+
+        List<CategoryGroupResponseDto> result = questionService.getQuestionSetByUserId(userId);
+
+        result.forEach(group -> {
+            group.questions().forEach(q -> System.out.println("  - [" + q.id() + "] " + q.content()));
+        });
+
+        assertThat(result).hasSize(2);
+        assertThat(result.get(0).category()).isEqualTo(CompetencyType.Category.협업_커뮤니케이션_역량);
+        assertThat(result.get(0).questions()).hasSize(2);
+    }
+
+    private Question createQuestion(int id, String content, CompetencyType type) {
+        Question q = new Question();
+        ReflectionTestUtils.setField(q, "id", id);
+        ReflectionTestUtils.setField(q, "content", content);
+        ReflectionTestUtils.setField(q, "competencyType", type);
+        return q;
+    }
+}

--- a/backend/api/src/test/java/com/yat2/episode/question/QuestionServiceTest.java
+++ b/backend/api/src/test/java/com/yat2/episode/question/QuestionServiceTest.java
@@ -36,45 +36,45 @@ class QuestionServiceTest {
     private QuestionService questionService;
 
     @Test
-    @DisplayName("사용자의 직무가 설정되지 않은 경우 JOB_NOT_SELECTED 예외가 발생한다")
-    void getQuestionSet_Fail_JobNotSelected() {
-        long userId = 12345678L;
-        User userWithoutJob = User.newUser(userId, "테스트유저");
+    @DisplayName("사용자의 직무가 설정되지 않은 경우 JOB_NOT_SELECTED 예외가 발생해야 한다")
+    void getQuestionSetByUserId_Fail_JobNotSelected() {
+        long userId = 1L;
+        User user = User.newUser(userId, "테스트유저");
 
-        given(userService.getUserOrThrow(userId)).willReturn(userWithoutJob);
+        given(userService.getUserOrThrow(userId)).willReturn(user);
 
         assertThatThrownBy(() -> questionService.getQuestionSetByUserId(userId)).isInstanceOf(CustomException.class)
                 .hasFieldOrPropertyWithValue("errorCode", ErrorCode.JOB_NOT_SELECTED);
     }
 
     @Test
-    @DisplayName("직무에 맞는 문항들을 조회하여 카테고리별로 그룹화하여 반환한다")
-    void getQuestionSet_Success() {
-        long userId = 12345678L;
+    @DisplayName("직무가 설정된 사용자의 경우, 문항을 카테고리별로 그룹화하여 반환해야 한다")
+    void getQuestionSetByUserId_Success() {
+        long userId = 1L;
         User user = User.newUser(userId, "테스트유저");
 
         Job job = new Job();
         ReflectionTestUtils.setField(job, "id", 10);
         user.updateJob(job);
 
-        CompetencyType typeA = mock(CompetencyType.class);
-        given(typeA.getCategory()).willReturn(CompetencyType.Category.협업_커뮤니케이션_역량);
+        CompetencyType type1 = mock(CompetencyType.class);
+        given(type1.getCategory()).willReturn(CompetencyType.Category.협업_커뮤니케이션_역량);
 
-        CompetencyType typeB = mock(CompetencyType.class);
-        given(typeB.getCategory()).willReturn(CompetencyType.Category.문제해결_사고_역량);
+        CompetencyType type2 = mock(CompetencyType.class);
+        given(type2.getCategory()).willReturn(CompetencyType.Category.문제해결_사고_역량);
 
-        Question q1 = createQuestion(1, "질문1", typeA);
-        Question q2 = createQuestion(2, "질문2", typeA);
-        Question q3 = createQuestion(3, "질문3", typeB);
+        Question q1 = createQuestion(1, "커뮤니케이션 질문", type1);
+        Question q2 = createQuestion(2, "문제해결 질문", type2);
 
         given(userService.getUserOrThrow(userId)).willReturn(user);
-        given(questionRepository.findAllWithCompetencyByJobId(10)).willReturn(List.of(q1, q2, q3));
+        given(questionRepository.findAllWithCompetencyByJobId(10)).willReturn(List.of(q1, q2));
 
         List<CategoryGroupResponseDto> result = questionService.getQuestionSetByUserId(userId);
 
         assertThat(result).hasSize(2);
+
         assertThat(result.get(0).category()).isEqualTo(CompetencyType.Category.협업_커뮤니케이션_역량);
-        assertThat(result.get(0).questions()).hasSize(2);
+        assertThat(result.get(1).category()).isEqualTo(CompetencyType.Category.문제해결_사고_역량);
     }
 
     private Question createQuestion(int id, String content, CompetencyType type) {


### PR DESCRIPTION
#297

# 목적
서비스 로직의 unit 테스트를 생성하여, 코드 작성 의도를 명확히 하고 리팩토링 시에 잘못 구현되는 경우를 예방합니다.

# 작업 내용
- job service 테스트 추가
- competency 테스트 추가
- question 테스트 추가

diagnosis와 mindmap 서비스는 현재 로직이 업데이트 중이어서, 제외하고 업로드합니다.

# 결과

<img width="306" height="106" alt="image" src="https://github.com/user-attachments/assets/f4750044-b8fa-4fac-b604-8c06ff4abb88" />
