### PR TITLE
[BE] 스웨거 표기 통일

### DIFF
--- a/backend/api/src/main/java/com/yat2/episode/competency/CompetencyTypeController.java
+++ b/backend/api/src/main/java/com/yat2/episode/competency/CompetencyTypeController.java
@@ -1,9 +1,5 @@
 package com.yat2.episode.competency;
 
-import com.yat2.episode.auth.security.Public;
-import com.yat2.episode.global.exception.ErrorCode;
-import com.yat2.episode.global.swagger.ApiErrorCodes;
-import com.yat2.episode.global.swagger.AuthRequiredErrors;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
@@ -18,8 +14,11 @@ import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 
-import com.yat2.episode.auth.AuthService;
+import com.yat2.episode.auth.security.Public;
 import com.yat2.episode.competency.dto.CompetencyTypeDto;
+import com.yat2.episode.global.exception.ErrorCode;
+import com.yat2.episode.global.swagger.ApiErrorCodes;
+import com.yat2.episode.global.swagger.AuthRequiredErrors;
 import com.yat2.episode.mindmap.MindmapService;
 
 import static com.yat2.episode.global.constant.RequestAttrs.USER_ID;
@@ -45,7 +44,7 @@ public class CompetencyTypeController {
     @Operation(summary = "특정 마인드맵 내 역량 리스트 조회")
     @ApiResponses({ @ApiResponse(responseCode = "200", description = "조회 성공") })
     @AuthRequiredErrors
-    @ApiErrorCodes({ErrorCode.INTERNAL_ERROR, ErrorCode.MINDMAP_NOT_FOUND})
+    @ApiErrorCodes({ ErrorCode.INTERNAL_ERROR, ErrorCode.MINDMAP_NOT_FOUND })
     @GetMapping("/mindmap/{mindmapId}")
     public ResponseEntity<List<CompetencyTypeDto>> getCompetenciesInMindmap(
             @RequestAttribute(USER_ID) long userId,

--- a/backend/api/src/main/java/com/yat2/episode/competency/CompetencyTypeController.java
+++ b/backend/api/src/main/java/com/yat2/episode/competency/CompetencyTypeController.java
@@ -1,5 +1,13 @@
 package com.yat2.episode.competency;
 
+import com.yat2.episode.auth.security.Public;
+import com.yat2.episode.global.exception.ErrorCode;
+import com.yat2.episode.global.swagger.ApiErrorCodes;
+import com.yat2.episode.global.swagger.AuthRequiredErrors;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -19,17 +27,25 @@ import static com.yat2.episode.global.constant.RequestAttrs.USER_ID;
 @RequiredArgsConstructor
 @RestController
 @RequestMapping("/competency-type")
+@Tag(name = "competency-type", description = "역량 조회 API")
 public class CompetencyTypeController {
 
     private final CompetencyTypeService competencyTypeService;
     private final MindmapService mindmapService;
-    private final AuthService authService;
 
+    @Public
+    @Operation(summary = "역량 리스트 조회")
+    @ApiResponses({ @ApiResponse(responseCode = "200", description = "조회 성공") })
+    @ApiErrorCodes(ErrorCode.INTERNAL_ERROR)
     @GetMapping
     public ResponseEntity<List<CompetencyTypeDto>> getAllCompetencies() {
         return ResponseEntity.ok(competencyTypeService.getAllData());
     }
 
+    @Operation(summary = "특정 마인드맵 내 역량 리스트 조회")
+    @ApiResponses({ @ApiResponse(responseCode = "200", description = "조회 성공") })
+    @AuthRequiredErrors
+    @ApiErrorCodes({ErrorCode.INTERNAL_ERROR, ErrorCode.MINDMAP_NOT_FOUND})
     @GetMapping("/mindmap/{mindmapId}")
     public ResponseEntity<List<CompetencyTypeDto>> getCompetenciesInMindmap(
             @RequestAttribute(USER_ID) long userId,

--- a/backend/api/src/main/java/com/yat2/episode/job/JobController.java
+++ b/backend/api/src/main/java/com/yat2/episode/job/JobController.java
@@ -1,9 +1,6 @@
 package com.yat2.episode.job;
 
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.media.ArraySchema;
-import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;

--- a/backend/api/src/main/java/com/yat2/episode/job/JobController.java
+++ b/backend/api/src/main/java/com/yat2/episode/job/JobController.java
@@ -30,13 +30,7 @@ public class JobController {
 
     @GetMapping
     @Operation(summary = "직군/직무 전체 조회", description = "직군(occupation) 목록을 가나다순으로 조회하고, 각 직군에 속한 직무(job) 목록도 함께 반환합니다.")
-    @ApiResponses(
-            { @ApiResponse(
-                    responseCode = "200", description = "조회 성공", content = @Content(
-                    array = @ArraySchema(schema = @Schema(implementation = JobsByOccupationDto.class))
-            )
-            ) }
-    )
+    @ApiResponses({ @ApiResponse(responseCode = "200", description = "조회 성공") })
     @ApiErrorCodes(ErrorCode.INTERNAL_ERROR)
     public ResponseEntity<List<JobsByOccupationDto>> getOccupationsWithJobs() {
         return ResponseEntity.ok(jobService.getOccupationsWithJobs());

--- a/backend/api/src/main/java/com/yat2/episode/mindmap/MindmapController.java
+++ b/backend/api/src/main/java/com/yat2/episode/mindmap/MindmapController.java
@@ -1,58 +1,37 @@
 package com.yat2.episode.mindmap;
 
 import com.github.f4b6a3.uuid.UuidCreator;
+import com.yat2.episode.global.exception.ErrorCode;
+import com.yat2.episode.global.swagger.ApiErrorCodes;
+import com.yat2.episode.global.swagger.AuthRequiredErrors;
+import com.yat2.episode.global.utils.UriUtil;
+import com.yat2.episode.mindmap.dto.*;
+import com.yat2.episode.mindmap.s3.dto.S3UploadResponseDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.CookieValue;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestAttribute;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.net.URI;
 import java.util.List;
 import java.util.UUID;
-
-import com.yat2.episode.auth.AuthService;
-import com.yat2.episode.global.exception.ErrorCode;
-import com.yat2.episode.global.exception.ErrorResponse;
-import com.yat2.episode.global.swagger.ApiErrorCodes;
-import com.yat2.episode.global.swagger.AuthRequiredErrors;
-import com.yat2.episode.global.utils.UriUtil;
-import com.yat2.episode.mindmap.dto.MindmapArgsReqDto;
-import com.yat2.episode.mindmap.dto.MindmapCreatedWithUrlDto;
-import com.yat2.episode.mindmap.dto.MindmapDataDto;
-import com.yat2.episode.mindmap.dto.MindmapDataExceptDateDto;
-import com.yat2.episode.mindmap.dto.MindmapIdentityDto;
-import com.yat2.episode.mindmap.dto.MindmapNameUpdateReqDto;
-import com.yat2.episode.mindmap.s3.S3SnapshotRepository;
-import com.yat2.episode.mindmap.s3.dto.S3UploadResponseDto;
 
 import static com.yat2.episode.global.constant.RequestAttrs.USER_ID;
 
 
 @RequiredArgsConstructor
 @RestController
+@AuthRequiredErrors
 @RequestMapping("/mindmap")
 @Tag(name = "Mindmap", description = "마인드맵 관리 API")
 public class MindmapController {
     private final MindmapService mindmapService;
-    private final AuthService authService;
-    private final S3SnapshotRepository s3SnapshotRepository;
 
     @Operation(
             summary = "마인드맵 목록 조회 (통합)", description = """
@@ -61,21 +40,14 @@ public class MindmapController {
             파라미터가 없으면 기본값은 ALL입니다.
             """
     )
-    @ApiResponses(
-            { @ApiResponse(responseCode = "200", description = "마인드맵 목록 조회 성공"), @ApiResponse(
-                    responseCode = "401", description = "인증 실패",
-                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
-            ), @ApiResponse(responseCode = "404", description = "존재하지 않는 사용자", content = @Content),
-              @ApiResponse(responseCode = "500", description = "서버 오류", content = @Content) }
-    )
+    @ApiResponses({@ApiResponse(responseCode = "200", description = "마인드맵 목록 조회 성공")})
+    @ApiErrorCodes({ErrorCode.INTERNAL_ERROR, ErrorCode.USER_NOT_FOUND})
     @GetMapping
-    public ResponseEntity<List<MindmapDataDto>> getMindmaps(
-            @CookieValue(name = "access_token", required = false) String token,
-            @Parameter(description = "조회할 마인드맵 유형 (ALL, PRIVATE, PUBLIC)")
-            @RequestParam(name = "type", required = false, defaultValue = "ALL")
-            MindmapVisibility type
+    public ResponseEntity<List<MindmapDataDto>> getMindmaps(@RequestAttribute(USER_ID) long userId,
+                                                            @Parameter(description = "조회할 마인드맵 유형 (ALL, PRIVATE, PUBLIC)")
+                                                            @RequestParam(name = "type", required = false, defaultValue = "ALL")
+                                                            MindmapVisibility type
     ) {
-        Long userId = authService.getUserIdByToken(token);
         return ResponseEntity.ok(mindmapService.getMindmaps(userId, type));
     }
 
@@ -84,12 +56,8 @@ public class MindmapController {
             입력된 마인드맵의 UUID를 기반으로 마인드맵 데이터를 조회합니다.
             """
     )
-    @ApiResponses(
-            { @ApiResponse(responseCode = "200", description = "마인드맵 조회 성공"),
-              @ApiResponse(responseCode = "401", description = "인증 실패(토큰 없음/만료/유효하지 않음)", content = @Content),
-              @ApiResponse(responseCode = "404", description = "존재하지 않는 사용자", content = @Content),
-              @ApiResponse(responseCode = "500", description = "서버 " + "오류", content = @Content) }
-    )
+    @ApiResponses({@ApiResponse(responseCode = "200", description = "마인드맵 조회 성공")})
+    @ApiErrorCodes({ErrorCode.INTERNAL_ERROR, ErrorCode.USER_NOT_FOUND, ErrorCode.MINDMAP_NOT_FOUND})
     @GetMapping("/{mindmapId}")
     public ResponseEntity<MindmapDataDto> getMindmap(
             @RequestAttribute(USER_ID) long userId,
@@ -104,14 +72,8 @@ public class MindmapController {
             마인드맵 선택 드롭다운, 사이드바 등에 사용됩니다.
             """
     )
-    @ApiResponses(
-            { @ApiResponse(responseCode = "200", description = "마인드맵 이름 목록 조회 성공"),
-              @ApiResponse(responseCode = "401", description = "인증 실패(토큰 없음/만료/유효하지 않음)", content = @Content),
-              @ApiResponse(responseCode = "404", description = "존재하지 않는 사용자", content = @Content),
-              @ApiResponse(responseCode = "500", description = "서버 " + "오류", content = @Content)
-
-            }
-    )
+    @ApiResponses({@ApiResponse(responseCode = "200", description = "마인드맵 이름 목록 조회 성공")})
+    @ApiErrorCodes({ErrorCode.INTERNAL_ERROR, ErrorCode.USER_NOT_FOUND})
     @GetMapping("/titles")
     public ResponseEntity<List<MindmapIdentityDto>> getMyMindmapNames(
             @RequestAttribute(USER_ID) long userId
@@ -129,17 +91,18 @@ public class MindmapController {
             """
     )
     @ApiResponses(
-            { @ApiResponse(responseCode = "201", description = "마인드맵 생성 성공"), @ApiResponse(
+            {@ApiResponse(responseCode = "201", description = "마인드맵 생성 성공"), @ApiResponse(
                     responseCode = "400", description = """
                     잘못된 요청
                     - MINDMAP_TITLE_REQUIRED: 팀 마인드맵 생성 시 제목 누락
                     """, content = @Content
             ), @ApiResponse(responseCode = "401", description = "인증 실패(토큰 없음/만료/유효하지 않음)", content = @Content),
-              @ApiResponse(responseCode = "404", description = "존재하지 않는 사용자", content = @Content),
-              @ApiResponse(responseCode = "500", description = "서버 오류", content = @Content)
+                    @ApiResponse(responseCode = "404", description = "존재하지 않는 사용자", content = @Content),
+                    @ApiResponse(responseCode = "500", description = "서버 오류", content = @Content)
 
             }
     )
+    @ApiErrorCodes({ErrorCode.INTERNAL_ERROR, ErrorCode.USER_NOT_FOUND, ErrorCode.S3_URL_FAIL, ErrorCode.MINDMAP_TITLE_REQUIRED})
     @PostMapping()
     public ResponseEntity<MindmapCreatedWithUrlDto> createMindmap(
             @RequestAttribute(USER_ID) long userId,
@@ -155,6 +118,7 @@ public class MindmapController {
 
     @PostMapping("/connect/{mindmapId}")
     public ResponseEntity<Object> connectMindmap(
+            @RequestAttribute(USER_ID) long userId,
             @PathVariable String mindmapId
     ) {
         // todo: userId 가져오기
@@ -165,6 +129,7 @@ public class MindmapController {
 
     @PostMapping("/disconnect/{mindmapId}")
     public ResponseEntity<Object> disconnectMindmap(
+            @RequestAttribute(USER_ID) long userId,
             @PathVariable String mindmapId
     ) {
         // todo: userId 가져오기
@@ -181,9 +146,8 @@ public class MindmapController {
             다른 참여자에게 영향이 가지 않습니다.
             """
     )
-    @ApiResponses({ @ApiResponse(responseCode = "204", description = "삭제 성공", content = @Content) })
-    @AuthRequiredErrors
-    @ApiErrorCodes({ ErrorCode.USER_NOT_FOUND, ErrorCode.INTERNAL_ERROR, ErrorCode.MINDMAP_NOT_FOUND })
+    @ApiResponses({@ApiResponse(responseCode = "204", description = "삭제 성공", content = @Content)})
+    @ApiErrorCodes({ErrorCode.USER_NOT_FOUND, ErrorCode.INTERNAL_ERROR, ErrorCode.MINDMAP_NOT_FOUND})
     @DeleteMapping("/{mindmapId}")
     public ResponseEntity<?> deleteMindmap(
             @RequestAttribute(USER_ID) long userId,
@@ -194,14 +158,8 @@ public class MindmapController {
     }
 
     @Operation(summary = "마인드맵 즐겨찾기 상태 변경", description = "마인드맵의 즐겨찾기 여부를 설정하거나 해제합니다.")
-    @ApiResponses(
-            { @ApiResponse(
-                    responseCode = "200", description = "업데이트 성공",
-                    content = @Content(schema = @Schema(implementation = MindmapDataDto.class))
-            ) }
-    )
-    @AuthRequiredErrors
-    @ApiErrorCodes({ ErrorCode.USER_NOT_FOUND, ErrorCode.INTERNAL_ERROR, ErrorCode.MINDMAP_NOT_FOUND })
+    @ApiResponses({@ApiResponse(responseCode = "200", description = "업데이트 성공")})
+    @ApiErrorCodes({ErrorCode.USER_NOT_FOUND, ErrorCode.INTERNAL_ERROR, ErrorCode.MINDMAP_NOT_FOUND})
     @PatchMapping("/{mindmapId}/favorite")
     public ResponseEntity<MindmapDataDto> updateFavoriteStatus(
             @RequestAttribute(USER_ID) long userId,
@@ -213,14 +171,8 @@ public class MindmapController {
     }
 
     @Operation(summary = "마인드맵 이름 변경", description = "마인드맵의 이름을 변경합니다. 팀 마인드맵 또한 모든 사용자에게 반영되는 수정 사항입니다.")
-    @ApiResponses(
-            { @ApiResponse(
-                    responseCode = "200", description = "업데이트 성공",
-                    content = @Content(schema = @Schema(implementation = MindmapDataDto.class))
-            ) }
-    )
-    @AuthRequiredErrors
-    @ApiErrorCodes({ ErrorCode.USER_NOT_FOUND, ErrorCode.INTERNAL_ERROR, ErrorCode.MINDMAP_NOT_FOUND })
+    @ApiResponses({@ApiResponse(responseCode = "200", description = "업데이트 성공")})
+    @ApiErrorCodes({ErrorCode.USER_NOT_FOUND, ErrorCode.INTERNAL_ERROR, ErrorCode.MINDMAP_NOT_FOUND})
     @PatchMapping("/{mindmapId}/name")
     public ResponseEntity<MindmapDataDto> updateName(
             @RequestAttribute(USER_ID) long userId,

--- a/backend/api/src/main/java/com/yat2/episode/mindmap/MindmapController.java
+++ b/backend/api/src/main/java/com/yat2/episode/mindmap/MindmapController.java
@@ -90,18 +90,7 @@ public class MindmapController {
             웹 소켓 연결은 별도 요청이 필요합니다.
             """
     )
-    @ApiResponses(
-            {@ApiResponse(responseCode = "201", description = "마인드맵 생성 성공"), @ApiResponse(
-                    responseCode = "400", description = """
-                    잘못된 요청
-                    - MINDMAP_TITLE_REQUIRED: 팀 마인드맵 생성 시 제목 누락
-                    """, content = @Content
-            ), @ApiResponse(responseCode = "401", description = "인증 실패(토큰 없음/만료/유효하지 않음)", content = @Content),
-                    @ApiResponse(responseCode = "404", description = "존재하지 않는 사용자", content = @Content),
-                    @ApiResponse(responseCode = "500", description = "서버 오류", content = @Content)
-
-            }
-    )
+    @ApiResponses({@ApiResponse(responseCode = "201", description = "마인드맵 생성 성공")})
     @ApiErrorCodes({ErrorCode.INTERNAL_ERROR, ErrorCode.USER_NOT_FOUND, ErrorCode.S3_URL_FAIL, ErrorCode.MINDMAP_TITLE_REQUIRED})
     @PostMapping()
     public ResponseEntity<MindmapCreatedWithUrlDto> createMindmap(

--- a/backend/api/src/main/java/com/yat2/episode/mindmap/s3/S3PostSigner.java
+++ b/backend/api/src/main/java/com/yat2/episode/mindmap/s3/S3PostSigner.java
@@ -55,8 +55,10 @@ public class S3PostSigner {
                                                                         sessionToken, policyBase64, signature));
     }
 
-    private String buildPolicy(String bucket, String key, String credential, String xAmzDate, String sessionToken,
-                               String expiration) {
+    private String buildPolicy(
+            String bucket, String key, String credential, String xAmzDate, String sessionToken,
+            String expiration
+    ) {
         StringBuilder sb = new StringBuilder();
         sb.append("{");
         sb.append("\"expiration\":\"").append(expiration).append("\",");

--- a/backend/api/src/main/java/com/yat2/episode/question/QuestionController.java
+++ b/backend/api/src/main/java/com/yat2/episode/question/QuestionController.java
@@ -1,9 +1,5 @@
 package com.yat2.episode.question;
 
-import com.yat2.episode.global.exception.ErrorCode;
-import com.yat2.episode.global.swagger.ApiErrorCodes;
-import com.yat2.episode.global.swagger.AuthRequiredErrors;
-import com.yat2.episode.question.dto.QuestionsByCompetencyCategoryDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
@@ -17,6 +13,11 @@ import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 
+import com.yat2.episode.global.exception.ErrorCode;
+import com.yat2.episode.global.swagger.ApiErrorCodes;
+import com.yat2.episode.global.swagger.AuthRequiredErrors;
+import com.yat2.episode.question.dto.QuestionsByCompetencyCategoryDto;
+
 import static com.yat2.episode.global.constant.RequestAttrs.USER_ID;
 
 @RequiredArgsConstructor
@@ -29,8 +30,8 @@ public class QuestionController {
 
     @GetMapping()
     @Operation(summary = "세부 역량 별 문항 조회", description = "세부 역량 별 문항을 하나 씩 뽑아 목록으로 제공합니다.")
-    @ApiResponses({@ApiResponse(responseCode = "200", description = "조회 성공")})
-    @ApiErrorCodes({ErrorCode.INTERNAL_ERROR, ErrorCode.USER_NOT_FOUND, ErrorCode.JOB_NOT_SELECTED})
+    @ApiResponses({ @ApiResponse(responseCode = "200", description = "조회 성공") })
+    @ApiErrorCodes({ ErrorCode.INTERNAL_ERROR, ErrorCode.USER_NOT_FOUND, ErrorCode.JOB_NOT_SELECTED })
     public ResponseEntity<List<QuestionsByCompetencyCategoryDto>> getQuestionSet(
             @RequestAttribute(USER_ID) long userId
     ) {

--- a/backend/api/src/main/java/com/yat2/episode/question/QuestionController.java
+++ b/backend/api/src/main/java/com/yat2/episode/question/QuestionController.java
@@ -1,9 +1,10 @@
 package com.yat2.episode.question;
 
+import com.yat2.episode.global.exception.ErrorCode;
+import com.yat2.episode.global.swagger.ApiErrorCodes;
+import com.yat2.episode.global.swagger.AuthRequiredErrors;
+import com.yat2.episode.question.dto.QuestionsByCompetencyCategoryDto;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.media.ArraySchema;
-import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -16,12 +17,11 @@ import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 
-import com.yat2.episode.question.dto.QuestionsByCompetencyCategoryDto;
-
 import static com.yat2.episode.global.constant.RequestAttrs.USER_ID;
 
 @RequiredArgsConstructor
 @RestController
+@AuthRequiredErrors
 @RequestMapping("/question")
 @Tag(name = "Question", description = "역량 자가 진단용 문항 관련 API")
 public class QuestionController {
@@ -29,16 +29,8 @@ public class QuestionController {
 
     @GetMapping()
     @Operation(summary = "세부 역량 별 문항 조회", description = "세부 역량 별 문항을 하나 씩 뽑아 목록으로 제공합니다.")
-    @ApiResponses(
-            { @ApiResponse(
-                    responseCode = "200", description = "조회 성공", content = @Content(
-                    array = @ArraySchema(schema = @Schema(implementation = QuestionsByCompetencyCategoryDto.class))
-            )
-            ), @ApiResponse(responseCode = "400", description = "직무 미션택", content = @Content), @ApiResponse(
-                    responseCode = "401", description = "인증 " + "실패(토큰 없음/만료/유효하지 않음)", content = @Content
-            ), @ApiResponse(responseCode = "404", description = "존재하지 않는 " + "사용자", content = @Content),
-              @ApiResponse(responseCode = "500", description = "서버 오류", content = @Content) }
-    )
+    @ApiResponses({@ApiResponse(responseCode = "200", description = "조회 성공")})
+    @ApiErrorCodes({ErrorCode.INTERNAL_ERROR, ErrorCode.USER_NOT_FOUND, ErrorCode.JOB_NOT_SELECTED})
     public ResponseEntity<List<QuestionsByCompetencyCategoryDto>> getQuestionSet(
             @RequestAttribute(USER_ID) long userId
     ) {

--- a/backend/api/src/main/resources/application.yml
+++ b/backend/api/src/main/resources/application.yml
@@ -40,6 +40,7 @@ spring:
 
 server:
   port: 8080
+  forward-headers-strategy: framework
 
 # ===============================
 # Custom & Third-party Settings


### PR DESCRIPTION
Closes #308

# 목적
스웨거 문서와 코드 내 어노테이션의 통일성 향상

# 작업 내용
- AuthRequiredErrors 및 ApiErrorCodes 기반 에러 응답 표기로 수정

# 결과
<img width="698" height="284" alt="image" src="https://github.com/user-attachments/assets/4c81062a-d765-443d-9d63-986b6efe6155" />

기존 누락되었던 controller에서도 위 형식으로 auth 에러를 볼 수 있게 됨.