### PR TITLE
[BE] api endpoint 복수형 통일

### DIFF
--- a/backend/api/src/main/java/com/yat2/episode/competency/CompetencyTypeController.java
+++ b/backend/api/src/main/java/com/yat2/episode/competency/CompetencyTypeController.java
@@ -45,7 +45,7 @@ public class CompetencyTypeController {
     @ApiResponses({ @ApiResponse(responseCode = "200", description = "조회 성공") })
     @AuthRequiredErrors
     @ApiErrorCodes({ ErrorCode.INTERNAL_ERROR, ErrorCode.MINDMAP_NOT_FOUND })
-    @GetMapping("/mindmap/{mindmapId}")
+    @GetMapping("/mindmaps/{mindmapId}")
     public ResponseEntity<List<CompetencyTypeDto>> getCompetenciesInMindmap(
             @RequestAttribute(USER_ID) long userId,
             @PathVariable String mindmapId

--- a/backend/api/src/main/java/com/yat2/episode/competency/CompetencyTypeController.java
+++ b/backend/api/src/main/java/com/yat2/episode/competency/CompetencyTypeController.java
@@ -25,7 +25,7 @@ import static com.yat2.episode.global.constant.RequestAttrs.USER_ID;
 
 @RequiredArgsConstructor
 @RestController
-@RequestMapping("/competency-type")
+@RequestMapping("/competency-types")
 @Tag(name = "competency-type", description = "역량 조회 API")
 public class CompetencyTypeController {
 

--- a/backend/api/src/main/java/com/yat2/episode/diagnosis/DiagnosisController.java
+++ b/backend/api/src/main/java/com/yat2/episode/diagnosis/DiagnosisController.java
@@ -26,7 +26,6 @@ import com.yat2.episode.global.exception.ErrorCode;
 import com.yat2.episode.global.swagger.ApiErrorCodes;
 import com.yat2.episode.global.swagger.AuthRequiredErrors;
 import com.yat2.episode.global.utils.UriUtil;
-import com.yat2.episode.user.UserService;
 
 import static com.yat2.episode.global.constant.RequestAttrs.USER_ID;
 
@@ -34,11 +33,10 @@ import static com.yat2.episode.global.constant.RequestAttrs.USER_ID;
 @AuthRequiredErrors
 @RequiredArgsConstructor
 @Validated
-@RequestMapping("/diagnosis")
+@RequestMapping("/diagnoses")
 @Tag(name = "Diagnosis", description = "역량 진단 관리 API")
 public class DiagnosisController {
     private final DiagnosisService diagnosisService;
-    private final UserService userService;
 
     @Operation(summary = "나의 진단 리스트 조회")
     @ApiResponses({ @ApiResponse(responseCode = "200", description = "조회 성공") })

--- a/backend/api/src/main/java/com/yat2/episode/job/JobController.java
+++ b/backend/api/src/main/java/com/yat2/episode/job/JobController.java
@@ -20,7 +20,7 @@ import com.yat2.episode.job.dto.JobsByOccupationDto;
 @Public
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/job")
+@RequestMapping("/jobs")
 @Tag(name = "Job", description = "직군/직무 조회 API")
 public class JobController {
     private final JobService jobService;

--- a/backend/api/src/main/java/com/yat2/episode/mindmap/MindmapController.java
+++ b/backend/api/src/main/java/com/yat2/episode/mindmap/MindmapController.java
@@ -43,7 +43,7 @@ import static com.yat2.episode.global.constant.RequestAttrs.USER_ID;
 @RequiredArgsConstructor
 @RestController
 @AuthRequiredErrors
-@RequestMapping("/mindmap")
+@RequestMapping("/mindmaps")
 @Tag(name = "Mindmap", description = "마인드맵 관리 API")
 public class MindmapController {
     private final MindmapService mindmapService;

--- a/backend/api/src/main/java/com/yat2/episode/question/QuestionController.java
+++ b/backend/api/src/main/java/com/yat2/episode/question/QuestionController.java
@@ -20,7 +20,7 @@ import com.yat2.episode.question.dto.QuestionsByCompetencyCategoryDto;
 @RequiredArgsConstructor
 @RestController
 @Public
-@RequestMapping("/question")
+@RequestMapping("/questions")
 @Tag(name = "Question", description = "역량 자가 진단용 문항 관련 API")
 public class QuestionController {
     private final QuestionService questionService;


### PR DESCRIPTION
Closes #318

# 목적
엔티티와 연결된 api endpoint를 restful하게 복수형으로 통일합니다.

# 작업 내용
- endpoint 복수형으로 변경
  - competency-type
  - diagnosis
  - job
  - mindmap
  - question

# 결과
<img width="1020" height="137" alt="image" src="https://github.com/user-attachments/assets/5d4724c1-db7b-4e2c-b6f5-06979dfd6b47" />
<img width="974" height="695" alt="image" src="https://github.com/user-attachments/assets/6f716d22-79b0-4b28-8076-413d21b98ecc" />
