### PR TITLE
[BE] test 방식을 h2에서 mysql container로 변경

### DIFF
--- a/backend/api/build.gradle
+++ b/backend/api/build.gradle
@@ -53,7 +53,8 @@ dependencies {
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.boot:spring-boot-starter-data-jpa-test'
-    testRuntimeOnly 'com.h2database:h2'
+    testImplementation "org.testcontainers:junit-jupiter:1.19.7"
+    testImplementation "org.testcontainers:mysql:1.19.7"
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
     implementation platform('software.amazon.awssdk:bom:2.21.0')

--- a/backend/api/src/test/java/com/yat2/episode/competency/CompetencyTypeRepositoryTest.java
+++ b/backend/api/src/test/java/com/yat2/episode/competency/CompetencyTypeRepositoryTest.java
@@ -1,6 +1,5 @@
 package com.yat2.episode.competency;
 
-import com.yat2.episode.utils.AbstractRepositoryTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -9,6 +8,8 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.Set;
+
+import com.yat2.episode.utils.AbstractRepositoryTest;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/backend/api/src/test/java/com/yat2/episode/competency/CompetencyTypeRepositoryTest.java
+++ b/backend/api/src/test/java/com/yat2/episode/competency/CompetencyTypeRepositoryTest.java
@@ -1,5 +1,6 @@
 package com.yat2.episode.competency;
 
+import com.yat2.episode.utils.AbstractRepositoryTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -13,7 +14,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @DataJpaTest
 @ActiveProfiles("test")
-class CompetencyTypeRepositoryTest {
+class CompetencyTypeRepositoryTest extends AbstractRepositoryTest {
 
     @Autowired
     private CompetencyTypeRepository competencyTypeRepository;

--- a/backend/api/src/test/java/com/yat2/episode/diagnosis/DiagnosisRepositoryTest.java
+++ b/backend/api/src/test/java/com/yat2/episode/diagnosis/DiagnosisRepositoryTest.java
@@ -1,5 +1,17 @@
 package com.yat2.episode.diagnosis;
 
+import com.yat2.episode.competency.CompetencyType;
+import com.yat2.episode.competency.CompetencyTypeRepository;
+import com.yat2.episode.diagnosis.dto.DiagnosisSummaryRes;
+import com.yat2.episode.job.Job;
+import com.yat2.episode.job.JobRepository;
+import com.yat2.episode.job.Occupation;
+import com.yat2.episode.job.OccupationRepository;
+import com.yat2.episode.question.Question;
+import com.yat2.episode.question.QuestionRepository;
+import com.yat2.episode.user.User;
+import com.yat2.episode.user.UserRepository;
+import com.yat2.episode.utils.AbstractRepositoryTest;
 import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -12,26 +24,13 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
-import com.yat2.episode.competency.CompetencyType;
-import com.yat2.episode.competency.CompetencyTypeRepository;
-import com.yat2.episode.diagnosis.dto.DiagnosisSummaryRes;
-import com.yat2.episode.job.Job;
-import com.yat2.episode.job.JobRepository;
-import com.yat2.episode.job.Occupation;
-import com.yat2.episode.job.OccupationRepository;
-import com.yat2.episode.question.Question;
-import com.yat2.episode.question.QuestionRepository;
-import com.yat2.episode.user.User;
-import com.yat2.episode.user.UserRepository;
-
 import static com.yat2.episode.utils.TestEntityFactory.createEntity;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @DataJpaTest
 @ActiveProfiles("test")
 @DisplayName("DiagnosisRepository 통합 테스트")
-class DiagnosisRepositoryTest {
-
+class DiagnosisRepositoryTest extends AbstractRepositoryTest {
     @Autowired
     private DiagnosisRepository diagnosisRepository;
     @Autowired

--- a/backend/api/src/test/java/com/yat2/episode/diagnosis/DiagnosisRepositoryTest.java
+++ b/backend/api/src/test/java/com/yat2/episode/diagnosis/DiagnosisRepositoryTest.java
@@ -1,5 +1,17 @@
 package com.yat2.episode.diagnosis;
 
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
 import com.yat2.episode.competency.CompetencyType;
 import com.yat2.episode.competency.CompetencyTypeRepository;
 import com.yat2.episode.diagnosis.dto.DiagnosisSummaryRes;
@@ -12,17 +24,6 @@ import com.yat2.episode.question.QuestionRepository;
 import com.yat2.episode.user.User;
 import com.yat2.episode.user.UserRepository;
 import com.yat2.episode.utils.AbstractRepositoryTest;
-import jakarta.persistence.EntityManager;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.util.ReflectionTestUtils;
-
-import java.time.LocalDateTime;
-import java.util.List;
-import java.util.Optional;
 
 import static com.yat2.episode.utils.TestEntityFactory.createEntity;
 import static org.assertj.core.api.Assertions.assertThat;

--- a/backend/api/src/test/java/com/yat2/episode/job/JobRepositoryTest.java
+++ b/backend/api/src/test/java/com/yat2/episode/job/JobRepositoryTest.java
@@ -1,6 +1,5 @@
 package com.yat2.episode.job;
 
-import com.yat2.episode.utils.AbstractRepositoryTest;
 import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -10,6 +9,8 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.List;
+
+import com.yat2.episode.utils.AbstractRepositoryTest;
 
 import static com.yat2.episode.utils.TestEntityFactory.createEntity;
 import static org.assertj.core.api.Assertions.assertThat;

--- a/backend/api/src/test/java/com/yat2/episode/job/JobRepositoryTest.java
+++ b/backend/api/src/test/java/com/yat2/episode/job/JobRepositoryTest.java
@@ -1,5 +1,6 @@
 package com.yat2.episode.job;
 
+import com.yat2.episode.utils.AbstractRepositoryTest;
 import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -7,7 +8,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.util.ReflectionTestUtils;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
@@ -15,11 +15,9 @@ import static com.yat2.episode.utils.TestEntityFactory.createEntity;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @DataJpaTest
-@Transactional
 @ActiveProfiles("test")
 @DisplayName("JobRepository 통합 테스트")
-class JobRepositoryTest {
-
+class JobRepositoryTest extends AbstractRepositoryTest {
     @Autowired
     private JobRepository jobRepository;
 

--- a/backend/api/src/test/java/com/yat2/episode/mindmap/MindmapRepositoryTest.java
+++ b/backend/api/src/test/java/com/yat2/episode/mindmap/MindmapRepositoryTest.java
@@ -1,5 +1,8 @@
 package com.yat2.episode.mindmap;
 
+import com.yat2.episode.user.User;
+import com.yat2.episode.user.UserRepository;
+import com.yat2.episode.utils.AbstractRepositoryTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -12,9 +15,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
-import com.yat2.episode.user.User;
-import com.yat2.episode.user.UserRepository;
-
 import static com.yat2.episode.utils.TestEntityFactory.createEntity;
 import static com.yat2.episode.utils.TestEntityFactory.createMindmap;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -22,8 +22,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @DataJpaTest
 @ActiveProfiles("test")
 @DisplayName("MindmapRepository 통합 테스트")
-class MindmapRepositoryTest {
-
+class MindmapRepositoryTest extends AbstractRepositoryTest {
     @Autowired
     private MindmapRepository mindmapRepository;
 

--- a/backend/api/src/test/java/com/yat2/episode/mindmap/MindmapRepositoryTest.java
+++ b/backend/api/src/test/java/com/yat2/episode/mindmap/MindmapRepositoryTest.java
@@ -1,8 +1,5 @@
 package com.yat2.episode.mindmap;
 
-import com.yat2.episode.user.User;
-import com.yat2.episode.user.UserRepository;
-import com.yat2.episode.utils.AbstractRepositoryTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -14,6 +11,10 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+
+import com.yat2.episode.user.User;
+import com.yat2.episode.user.UserRepository;
+import com.yat2.episode.utils.AbstractRepositoryTest;
 
 import static com.yat2.episode.utils.TestEntityFactory.createEntity;
 import static com.yat2.episode.utils.TestEntityFactory.createMindmap;

--- a/backend/api/src/test/java/com/yat2/episode/question/QuestionRepositoryTest.java
+++ b/backend/api/src/test/java/com/yat2/episode/question/QuestionRepositoryTest.java
@@ -1,12 +1,5 @@
 package com.yat2.episode.question;
 
-import com.yat2.episode.competency.CompetencyType;
-import com.yat2.episode.competency.CompetencyTypeRepository;
-import com.yat2.episode.job.Job;
-import com.yat2.episode.job.JobRepository;
-import com.yat2.episode.job.Occupation;
-import com.yat2.episode.job.OccupationRepository;
-import com.yat2.episode.utils.AbstractRepositoryTest;
 import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -17,6 +10,14 @@ import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.List;
 import java.util.UUID;
+
+import com.yat2.episode.competency.CompetencyType;
+import com.yat2.episode.competency.CompetencyTypeRepository;
+import com.yat2.episode.job.Job;
+import com.yat2.episode.job.JobRepository;
+import com.yat2.episode.job.Occupation;
+import com.yat2.episode.job.OccupationRepository;
+import com.yat2.episode.utils.AbstractRepositoryTest;
 
 import static com.yat2.episode.utils.TestEntityFactory.createEntity;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -96,8 +97,6 @@ class QuestionRepositoryTest extends AbstractRepositoryTest {
         List<Question> result = questionRepository.findAllWithCompetency();
 
         assertThat(result).extracting(Question::getContent).contains(uniqueContent);
-        assertThat(result)
-                .extracting(qt -> qt.getCompetencyType().getTypeName())
-                .contains("페치조인 테스트");
+        assertThat(result).extracting(qt -> qt.getCompetencyType().getTypeName()).contains("페치조인 테스트");
     }
 }

--- a/backend/api/src/test/java/com/yat2/episode/question/QuestionRepositoryTest.java
+++ b/backend/api/src/test/java/com/yat2/episode/question/QuestionRepositoryTest.java
@@ -1,5 +1,12 @@
 package com.yat2.episode.question;
 
+import com.yat2.episode.competency.CompetencyType;
+import com.yat2.episode.competency.CompetencyTypeRepository;
+import com.yat2.episode.job.Job;
+import com.yat2.episode.job.JobRepository;
+import com.yat2.episode.job.Occupation;
+import com.yat2.episode.job.OccupationRepository;
+import com.yat2.episode.utils.AbstractRepositoryTest;
 import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -11,20 +18,13 @@ import org.springframework.test.util.ReflectionTestUtils;
 import java.util.List;
 import java.util.UUID;
 
-import com.yat2.episode.competency.CompetencyType;
-import com.yat2.episode.competency.CompetencyTypeRepository;
-import com.yat2.episode.job.Job;
-import com.yat2.episode.job.JobRepository;
-import com.yat2.episode.job.Occupation;
-import com.yat2.episode.job.OccupationRepository;
-
 import static com.yat2.episode.utils.TestEntityFactory.createEntity;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @DataJpaTest
 @ActiveProfiles("test")
 @DisplayName("QuestionRepository 통합 테스트")
-class QuestionRepositoryTest {
+class QuestionRepositoryTest extends AbstractRepositoryTest {
 
     @Autowired
     private QuestionRepository questionRepository;
@@ -96,6 +96,8 @@ class QuestionRepositoryTest {
         List<Question> result = questionRepository.findAllWithCompetency();
 
         assertThat(result).extracting(Question::getContent).contains(uniqueContent);
-        assertThat(result.get(0).getCompetencyType().getTypeName()).isEqualTo("페치조인 테스트");
+        assertThat(result)
+                .extracting(qt -> qt.getCompetencyType().getTypeName())
+                .contains("페치조인 테스트");
     }
 }

--- a/backend/api/src/test/java/com/yat2/episode/utils/AbstractRepositoryTest.java
+++ b/backend/api/src/test/java/com/yat2/episode/utils/AbstractRepositoryTest.java
@@ -10,10 +10,8 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 public abstract class AbstractRepositoryTest {
 
-    static final MySQLContainer<?> MYSQL = new MySQLContainer<>("mysql:8.0")
-            .withDatabaseName("testdb")
-            .withUsername("test")
-            .withPassword("test");
+    static final MySQLContainer<?> MYSQL =
+            new MySQLContainer<>("mysql:8.0").withDatabaseName("testdb").withUsername("test").withPassword("test");
 
     static {
         MYSQL.start();

--- a/backend/api/src/test/java/com/yat2/episode/utils/AbstractRepositoryTest.java
+++ b/backend/api/src/test/java/com/yat2/episode/utils/AbstractRepositoryTest.java
@@ -1,0 +1,29 @@
+package com.yat2.episode.utils;
+
+import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@Testcontainers
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+public abstract class AbstractRepositoryTest {
+
+    static final MySQLContainer<?> MYSQL = new MySQLContainer<>("mysql:8.0")
+            .withDatabaseName("testdb")
+            .withUsername("test")
+            .withPassword("test");
+
+    static {
+        MYSQL.start();
+    }
+
+    @DynamicPropertySource
+    static void configureProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", MYSQL::getJdbcUrl);
+        registry.add("spring.datasource.username", MYSQL::getUsername);
+        registry.add("spring.datasource.password", MYSQL::getPassword);
+        registry.add("spring.datasource.driver-class-name", () -> "com.mysql.cj.jdbc.Driver");
+    }
+}

--- a/backend/api/src/test/resources/application-test.yml
+++ b/backend/api/src/test/resources/application-test.yml
@@ -3,19 +3,11 @@ spring:
     name: episode-test
 
   flyway:
-    enabled: false
-
-  datasource:
-    url: jdbc:h2:mem:testdb;MODE=MySQL;DB_CLOSE_DELAY=-1;DATABASE_TO_LOWER=TRUE
-    driver-class-name: org.h2.Driver
-    username: sa
-    password:
-    type: com.zaxxer.hikari.HikariDataSource
+    enabled: true
 
   jpa:
-    database-platform: org.hibernate.dialect.H2Dialect
     hibernate:
-      ddl-auto: create-drop
+      ddl-auto: validate
     properties:
       hibernate:
         format_sql: true


### PR DESCRIPTION
Closes #336

# 목적
h2 기반 테스트와 mysql을 사용하는 실제 운영 서버 사이에서 호환성이 맞지 않는 부분이 다수 발견됨.

column json 데이터 join 문법이 다르다..
flyway 기반 ddl 업데이트가 안된다.. => mysql 문법으로 작성됨
실제 운영 서버와 동일한 환경에서 테스트를 수행함으로써 테스트에 들어가는 수정 오버헤드를 줄이고 환경 차이로 인한 문제 해결

# 작업 내용
- testcontainers 추가
- AbstractRepositoryTest Class를 통해 하나의 컨테이너를 활용한 테스트
- application-test의 h2 관련 설정 삭제
- flyway 적용

# 결과
<img width="788" height="156" alt="image" src="https://github.com/user-attachments/assets/6a9489e4-3626-4000-ad57-fb8740686dd4" />
