### PR TITLE
[FE] TextArea 존재하지 않는 type 적용 문제 해결

### DIFF
--- a/frontend/src/shared/components/textarea/TextArea.tsx
+++ b/frontend/src/shared/components/textarea/TextArea.tsx
@@ -5,7 +5,7 @@ import { InputVariants } from "@/shared/styles/input_variants";
 
 type MultilineInputProps = ComponentPropsWithoutRef<"textarea"> & VariantProps<typeof InputVariants>;
 
-export function TextArea({ placeholder, value, inputSize = "full", ...rest }: MultilineInputProps) {
+export function TextArea({ placeholder, value, inputSize = "lg", ...rest }: MultilineInputProps) {
     const status = value ? "filled" : "empty";
 
     return (


### PR DESCRIPTION
Closes #391 

# 목적
TextArea에 없는 타입 full을 기본값으로 적용하여 빌드에러가 나고 있었습니다. 기본값을 lg로 적용했습니다.

# 결과
TextArea 를 import 해서 사용도 잘 됩니다.
<img width="912" height="246" alt="image" src="https://github.com/user-attachments/assets/181ee488-6784-48e9-8c1d-42983a80ea96" />

빌드 잘됩니다.
<img width="576" height="93" alt="image" src="https://github.com/user-attachments/assets/fdee4284-f10d-4613-914e-e1809ab76ebd" />