### PR TITLE
[BE] snapshot 저장 시 dedupe 처리 삭제

### DIFF
--- a/backend/api/src/main/java/com/yat2/episode/collaboration/CollaborationService.java
+++ b/backend/api/src/main/java/com/yat2/episode/collaboration/CollaborationService.java
@@ -9,7 +9,6 @@ import org.springframework.web.socket.WebSocketSession;
 import java.nio.ByteBuffer;
 import java.util.UUID;
 
-import com.yat2.episode.collaboration.redis.JobStreamStore;
 import com.yat2.episode.collaboration.yjs.YjsMessageRouter;
 import com.yat2.episode.global.constant.AttributeKeys;
 
@@ -19,7 +18,6 @@ import com.yat2.episode.global.constant.AttributeKeys;
 public class CollaborationService {
     private final SessionRegistry sessionRegistry;
     private final YjsMessageRouter yjsMessageRouter;
-    private final JobStreamStore jobStreamStore;
 
     public void handleConnect(WebSocketSession session) {
         UUID roomId = getMindmapId(session);
@@ -46,7 +44,7 @@ public class CollaborationService {
 
         int remainingSession = sessionRegistry.removeSession(roomId, session);
         if (remainingSession == 0) {
-            jobStreamStore.publishSnapshot(roomId);
+            yjsMessageRouter.executeSnapshot(roomId);
         }
     }
 

--- a/backend/api/src/main/java/com/yat2/episode/collaboration/CollaborationService.java
+++ b/backend/api/src/main/java/com/yat2/episode/collaboration/CollaborationService.java
@@ -9,6 +9,7 @@ import org.springframework.web.socket.WebSocketSession;
 import java.nio.ByteBuffer;
 import java.util.UUID;
 
+import com.yat2.episode.collaboration.worker.JobPublisher;
 import com.yat2.episode.collaboration.yjs.YjsMessageRouter;
 import com.yat2.episode.global.constant.AttributeKeys;
 
@@ -18,6 +19,7 @@ import com.yat2.episode.global.constant.AttributeKeys;
 public class CollaborationService {
     private final SessionRegistry sessionRegistry;
     private final YjsMessageRouter yjsMessageRouter;
+    private final JobPublisher jobPublisher;
 
     public void handleConnect(WebSocketSession session) {
         UUID roomId = getMindmapId(session);
@@ -44,7 +46,7 @@ public class CollaborationService {
 
         int remainingSession = sessionRegistry.removeSession(roomId, session);
         if (remainingSession == 0) {
-            yjsMessageRouter.executeSnapshot(roomId);
+            jobPublisher.publishSnapshotAsync(roomId);
         }
     }
 

--- a/backend/api/src/main/java/com/yat2/episode/collaboration/config/CollaborationAsyncConfig.java
+++ b/backend/api/src/main/java/com/yat2/episode/collaboration/config/CollaborationAsyncConfig.java
@@ -18,8 +18,8 @@ public class CollaborationAsyncConfig {
 
     private final CollaborationAsyncProperties asyncProperties;
 
-    @Bean(name = "redisExecutor")
-    public Executor redisExecutor() {
+    @Bean(name = "updateExecutor")
+    public Executor updateExecutor() {
         ThreadPoolTaskExecutor exec = new ThreadPoolTaskExecutor();
         exec.setThreadNamePrefix(THREAD_PREFIX_UPDATE);
         exec.setCorePoolSize(asyncProperties.corePoolSize());

--- a/backend/api/src/main/java/com/yat2/episode/collaboration/config/CollaborationAsyncConfig.java
+++ b/backend/api/src/main/java/com/yat2/episode/collaboration/config/CollaborationAsyncConfig.java
@@ -13,14 +13,15 @@ import java.util.concurrent.Executor;
 @Configuration
 public class CollaborationAsyncConfig {
 
-    private static final String THREAD_PREFIX = "redis-append-";
+    private static final String THREAD_PREFIX_UPDATE = "redis-append-";
+    private static final String THREAD_PREFIX_SYNC = "sync-job-";
 
     private final CollaborationAsyncProperties asyncProperties;
 
     @Bean(name = "redisExecutor")
     public Executor redisExecutor() {
         ThreadPoolTaskExecutor exec = new ThreadPoolTaskExecutor();
-        exec.setThreadNamePrefix(THREAD_PREFIX);
+        exec.setThreadNamePrefix(THREAD_PREFIX_UPDATE);
         exec.setCorePoolSize(asyncProperties.corePoolSize());
         exec.setMaxPoolSize(asyncProperties.maxPoolSize());
         exec.setQueueCapacity(asyncProperties.queueCapacity());
@@ -31,4 +32,23 @@ public class CollaborationAsyncConfig {
         exec.initialize();
         return exec;
     }
+
+    @Bean(name = "jobExecutor")
+    public Executor jobExecutor() {
+        ThreadPoolTaskExecutor exec = new ThreadPoolTaskExecutor();
+        exec.setThreadNamePrefix(THREAD_PREFIX_SYNC);
+
+        exec.setCorePoolSize(asyncProperties.corePoolSize());
+        exec.setMaxPoolSize(asyncProperties.maxPoolSize());
+
+        exec.setQueueCapacity(asyncProperties.queueCapacity());
+        exec.setKeepAliveSeconds(asyncProperties.keepAliveSeconds());
+        exec.setAllowCoreThreadTimeOut(true);
+
+        exec.setRejectedExecutionHandler(new java.util.concurrent.ThreadPoolExecutor.CallerRunsPolicy());
+
+        exec.initialize();
+        return exec;
+    }
+
 }

--- a/backend/api/src/main/java/com/yat2/episode/collaboration/config/CollaborationAsyncProperties.java
+++ b/backend/api/src/main/java/com/yat2/episode/collaboration/config/CollaborationAsyncProperties.java
@@ -9,5 +9,6 @@ public record CollaborationAsyncProperties(
         int queueCapacity,
         int keepAliveSeconds,
         boolean allowCoreThreadTimeout,
-        long dropLogIntervalMs
+        long dropLogIntervalMs,
+        int updateAppendMaxRetries
 ) {}

--- a/backend/api/src/main/java/com/yat2/episode/collaboration/redis/JobStreamStore.java
+++ b/backend/api/src/main/java/com/yat2/episode/collaboration/redis/JobStreamStore.java
@@ -32,7 +32,7 @@ public class JobStreamStore {
     }
 
     private void publish(JobType type, UUID roomId, Duration dedupeTtl) {
-        if (!tryDedupe(type, roomId, dedupeTtl)) {
+        if (type != JobType.SNAPSHOT && !tryDedupe(type, roomId, dedupeTtl)) {
             return;
         }
 

--- a/backend/api/src/main/java/com/yat2/episode/collaboration/redis/JobStreamStore.java
+++ b/backend/api/src/main/java/com/yat2/episode/collaboration/redis/JobStreamStore.java
@@ -32,15 +32,15 @@ public class JobStreamStore {
     }
 
     private void publish(JobType type, UUID roomId, Duration dedupeTtl) {
-        if (type != JobType.SNAPSHOT && !tryDedupe(type, roomId, dedupeTtl)) {
-            return;
-        }
-
-        Map<String, String> fields = new HashMap<>();
-        fields.put(redisProperties.jobStream().fields().type(), type.name());
-        fields.put(redisProperties.jobStream().fields().roomId(), roomId.toString());
-
         try {
+            if (type != JobType.SNAPSHOT && !tryDedupe(type, roomId, dedupeTtl)) {
+                return;
+            }
+
+            Map<String, String> fields = new HashMap<>();
+            fields.put(redisProperties.jobStream().fields().type(), type.name());
+            fields.put(redisProperties.jobStream().fields().roomId(), roomId.toString());
+
             StreamOperations<String, String, String> ops = stringRedisTemplate.opsForStream();
             MapRecord<String, String, String> record =
                     StreamRecords.newRecord().in(redisProperties.jobStream().key()).ofMap(fields);

--- a/backend/api/src/main/java/com/yat2/episode/collaboration/worker/JobPublisher.java
+++ b/backend/api/src/main/java/com/yat2/episode/collaboration/worker/JobPublisher.java
@@ -1,7 +1,6 @@
 package com.yat2.episode.collaboration.worker;
 
 
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
@@ -14,11 +13,17 @@ import com.yat2.episode.collaboration.redis.JobStreamStore;
 
 @Slf4j
 @Component
-@RequiredArgsConstructor
 public class JobPublisher {
     private final JobStreamStore jobStreamStore;
-    @Qualifier("jobExecutor")
     private final Executor jobExecutor;
+
+    public JobPublisher(
+            JobStreamStore jobStreamStore,
+            @Qualifier("jobExecutor") Executor jobExecutor
+    ) {
+        this.jobStreamStore = jobStreamStore;
+        this.jobExecutor = jobExecutor;
+    }
 
     public void publishSyncAsync(UUID roomId) {
         executeSafely(() -> jobStreamStore.publishSync(roomId), JobType.SYNC.name(), roomId);

--- a/backend/api/src/main/java/com/yat2/episode/collaboration/worker/JobPublisher.java
+++ b/backend/api/src/main/java/com/yat2/episode/collaboration/worker/JobPublisher.java
@@ -1,0 +1,43 @@
+package com.yat2.episode.collaboration.worker;
+
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Component;
+
+import java.util.UUID;
+import java.util.concurrent.Executor;
+
+import com.yat2.episode.collaboration.JobType;
+import com.yat2.episode.collaboration.redis.JobStreamStore;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JobPublisher {
+    private final JobStreamStore jobStreamStore;
+    @Qualifier("jobExecutor")
+    private final Executor jobExecutor;
+
+    public void publishSyncAsync(UUID roomId) {
+        executeSafely(() -> jobStreamStore.publishSync(roomId), JobType.SYNC.name(), roomId);
+    }
+
+    public void publishSnapshotAsync(UUID roomId) {
+        executeSafely(() -> jobStreamStore.publishSnapshot(roomId), JobType.SNAPSHOT.name(), roomId);
+    }
+
+    private void executeSafely(Runnable task, String type, UUID roomId) {
+        try {
+            jobExecutor.execute(task);
+        } catch (Exception e) {
+            log.warn("jobExecutor rejected. running inline. type={}, roomId={}", type, roomId, e);
+            try {
+                task.run();
+            } catch (Exception ex) {
+                log.error("Job publish failed. type={}, roomId={}", type, roomId, ex);
+            }
+        }
+    }
+}

--- a/backend/api/src/main/java/com/yat2/episode/collaboration/worker/UpdateAppender.java
+++ b/backend/api/src/main/java/com/yat2/episode/collaboration/worker/UpdateAppender.java
@@ -17,12 +17,12 @@ public class UpdateAppender {
     private final UpdateStreamStore updateStreamStore;
     private final JobPublisher jobPublisher;
 
-    @Qualifier("redisExecutor")
-    private final Executor redisExecutor;
+    @Qualifier("updateExecutor")
+    private final Executor updateExecutor;
 
     public void appendUpdateAsync(UUID roomId, byte[] payload) {
         try {
-            redisExecutor.execute(() -> tryAppend(roomId, payload));
+            updateExecutor.execute(() -> tryAppend(roomId, payload));
         } catch (Exception e) {
             jobPublisher.publishSyncAsync(roomId);
         }

--- a/backend/api/src/main/java/com/yat2/episode/collaboration/worker/UpdateAppender.java
+++ b/backend/api/src/main/java/com/yat2/episode/collaboration/worker/UpdateAppender.java
@@ -1,0 +1,60 @@
+package com.yat2.episode.collaboration.worker;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Component;
+
+import java.util.UUID;
+import java.util.concurrent.Executor;
+
+import com.yat2.episode.collaboration.redis.UpdateStreamStore;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class UpdateAppender {
+    private final UpdateStreamStore updateStreamStore;
+    private final JobPublisher jobPublisher;
+
+    @Qualifier("redisExecutor")
+    private final Executor redisExecutor;
+
+    public void appendUpdateAsync(UUID roomId, byte[] payload) {
+        try {
+            redisExecutor.execute(() -> tryAppend(roomId, payload));
+        } catch (Exception e) {
+            jobPublisher.publishSyncAsync(roomId);
+        }
+    }
+
+    private void tryAppend(UUID roomId, byte[] payload) {
+        for (int i = 0; i < 5; i++) {
+            try {
+                updateStreamStore.appendUpdate(roomId, payload);
+                return;
+            } catch (Exception e) {
+                if (isFatalRedisWrite(e)) {
+                    log.error("Fatal redis write. roomId={}", roomId, e);
+                    // todo: 다른 방법 도모..?
+                    // 저희가 같은 redis 인스턴스 내에서 job 처리를 하고 있어서, fatal error 시에는 sync 시도가 무의미하다고 판단됩니다.
+                    return;
+                }
+                log.warn("Redis append failed (retryable). roomId={}, attempt={}", roomId, i + 1, e);
+            }
+        }
+        jobPublisher.publishSyncAsync(roomId);
+    }
+
+    private boolean isFatalRedisWrite(Exception exception) {
+        String msg = getRootMessage(exception);
+        return msg.contains("OOM command not allowed") || msg.contains("MISCONF") || msg.contains("READONLY") ||
+               msg.contains("NOPERM");
+    }
+
+    private String getRootMessage(Throwable e) {
+        Throwable t = e;
+        while (t.getCause() != null) t = t.getCause();
+        return t.getMessage() == null ? "" : t.getMessage();
+    }
+}

--- a/backend/api/src/main/java/com/yat2/episode/collaboration/yjs/YjsMessageRouter.java
+++ b/backend/api/src/main/java/com/yat2/episode/collaboration/yjs/YjsMessageRouter.java
@@ -63,6 +63,12 @@ public class YjsMessageRouter {
         sessionRegistry.broadcast(roomId, sender, payload);
     }
 
+    public void executeSnapshot(UUID roomId) {
+        jobExecutor.execute(() -> {
+            jobStreamStore.publishSnapshot(roomId);
+        });
+    }
+
     private void handleSync1(UUID roomId, WebSocketSession requester, byte[] payload) {
 
         List<WebSocketSession> candidates = sessionRegistry.findAllAlivePeers(roomId, requester.getId());

--- a/backend/api/src/main/java/com/yat2/episode/collaboration/yjs/YjsMessageRouter.java
+++ b/backend/api/src/main/java/com/yat2/episode/collaboration/yjs/YjsMessageRouter.java
@@ -21,17 +21,20 @@ public class YjsMessageRouter {
     private final SessionRegistry sessionRegistry;
     private final UpdateStreamStore updateStreamStore;
     private final Executor redisExecutor;
+    private final Executor jobExecutor;
     private final JobStreamStore jobStreamStore;
 
     private final ConcurrentHashMap<UUID, ConcurrentHashMap<String, String>> pendingSyncs = new ConcurrentHashMap<>();
 
     public YjsMessageRouter(
             SessionRegistry sessionRegistry, UpdateStreamStore updateStreamStore,
-            @Qualifier("redisExecutor") Executor redisExecutor, JobStreamStore jobStreamStore
+            @Qualifier("redisExecutor") Executor redisExecutor,
+            @Qualifier("jobExecutor") Executor jobExecutor, JobStreamStore jobStreamStore
     ) {
         this.sessionRegistry = sessionRegistry;
         this.updateStreamStore = updateStreamStore;
         this.redisExecutor = redisExecutor;
+        this.jobExecutor = jobExecutor;
         this.jobStreamStore = jobStreamStore;
     }
 
@@ -146,7 +149,7 @@ public class YjsMessageRouter {
             } catch (Exception e) {
                 if (isFatalRedisWrite(e)) {
                     log.error("Fatal redis write. roomId={}", roomId, e);
-                    
+
                     // todo: 다른 방법 도모..?
                     // 저희가 같은 redis 인스턴스 내에서 job 처리를 하고 있어서, fatal error 시에는 sync 시도가 무의미하다고 판단됩니다.
                     return;

--- a/backend/api/src/main/java/com/yat2/episode/collaboration/yjs/YjsMessageRouter.java
+++ b/backend/api/src/main/java/com/yat2/episode/collaboration/yjs/YjsMessageRouter.java
@@ -129,7 +129,9 @@ public class YjsMessageRouter {
                 tryUpdateAppend(roomId, payload);
             });
         } catch (Exception e) {
-            tryPublishSync(roomId);
+            jobExecutor.execute(() -> {
+                tryPublishSync(roomId);
+            });
         }
     }
 
@@ -157,7 +159,9 @@ public class YjsMessageRouter {
                 log.warn("Redis append failed (retryable). roomId={}, attempt={}", roomId, i + 1, e);
             }
         }
-        tryPublishSync(roomId);
+        jobExecutor.execute(() -> {
+            tryPublishSync(roomId);
+        });
     }
 
     private boolean isFatalRedisWrite(Exception exception) {

--- a/backend/api/src/main/resources/application.yml
+++ b/backend/api/src/main/resources/application.yml
@@ -161,3 +161,4 @@ collaboration:
       keep-alive-seconds: 30
       allow-core-thread-timeout: true
       drop-log-interval-ms: 1000
+      update-append-max-retries: 5

--- a/backend/api/src/test/java/com/yat2/episode/collaboration/CollaborationServiceTest.java
+++ b/backend/api/src/test/java/com/yat2/episode/collaboration/CollaborationServiceTest.java
@@ -16,6 +16,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 
+import com.yat2.episode.collaboration.worker.JobPublisher;
 import com.yat2.episode.collaboration.yjs.YjsMessageRouter;
 import com.yat2.episode.global.constant.AttributeKeys;
 
@@ -41,11 +42,14 @@ class CollaborationServiceTest {
     @Mock
     YjsMessageRouter yjsMessageRouter;
 
+    @Mock
+    JobPublisher jobPublisher;
+
     CollaborationService service;
 
     @BeforeEach
     void setUp() {
-        service = new CollaborationService(sessionRegistry, yjsMessageRouter);
+        service = new CollaborationService(sessionRegistry, yjsMessageRouter, jobPublisher);
     }
 
     @Nested
@@ -88,7 +92,7 @@ class CollaborationServiceTest {
             order.verify(yjsMessageRouter).onDisconnect(roomId, "S-1");
             order.verify(sessionRegistry).removeSession(roomId, session);
 
-            verify(yjsMessageRouter, never()).executeSnapshot(any(UUID.class));
+            verify(jobPublisher, never()).publishSnapshotAsync(any(UUID.class));
             verifyNoMoreInteractions(yjsMessageRouter, sessionRegistry);
         }
 
@@ -107,10 +111,10 @@ class CollaborationServiceTest {
 
             service.handleDisconnect(session);
 
-            InOrder order = inOrder(yjsMessageRouter, sessionRegistry);
+            InOrder order = inOrder(yjsMessageRouter, sessionRegistry, jobPublisher);
             order.verify(yjsMessageRouter).onDisconnect(roomId, "S-1");
             order.verify(sessionRegistry).removeSession(roomId, session);
-            order.verify(yjsMessageRouter).executeSnapshot(roomId);
+            order.verify(jobPublisher).publishSnapshotAsync(roomId);
 
             verifyNoMoreInteractions(yjsMessageRouter, sessionRegistry);
         }

--- a/backend/api/src/test/java/com/yat2/episode/collaboration/worker/JobPublisherTest.java
+++ b/backend/api/src/test/java/com/yat2/episode/collaboration/worker/JobPublisherTest.java
@@ -1,0 +1,113 @@
+package com.yat2.episode.collaboration.worker;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.UUID;
+import java.util.concurrent.Executor;
+
+import com.yat2.episode.collaboration.redis.JobStreamStore;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("JobPublisher 단위 테스트")
+class JobPublisherTest {
+
+    @Mock
+    JobStreamStore jobStreamStore;
+
+    @Mock
+    Executor jobExecutor;
+
+    JobPublisher jobPublisher;
+
+    @BeforeEach
+    void setUp() {
+        jobPublisher = new JobPublisher(jobStreamStore, jobExecutor);
+    }
+
+    @Test
+    @DisplayName("publishSyncAsync는 jobExecutor에 작업을 위임하고, 실행되면 publishSync가 호출된다")
+    void publishSyncAsync_delegatesToExecutor_andPublishes() {
+        UUID roomId = UUID.randomUUID();
+
+        jobPublisher.publishSyncAsync(roomId);
+
+        ArgumentCaptor<Runnable> taskCaptor = ArgumentCaptor.forClass(Runnable.class);
+        verify(jobExecutor).execute(taskCaptor.capture());
+
+        assertThatCode(() -> taskCaptor.getValue().run()).doesNotThrowAnyException();
+        verify(jobStreamStore).publishSync(roomId);
+        verify(jobStreamStore, never()).publishSnapshot(any());
+    }
+
+    @Test
+    @DisplayName("publishSnapshotAsync는 jobExecutor에 작업을 위임하고, 실행되면 publishSnapshot이 호출된다")
+    void publishSnapshotAsync_delegatesToExecutor_andPublishes() {
+        UUID roomId = UUID.randomUUID();
+
+        jobPublisher.publishSnapshotAsync(roomId);
+
+        ArgumentCaptor<Runnable> taskCaptor = ArgumentCaptor.forClass(Runnable.class);
+        verify(jobExecutor).execute(taskCaptor.capture());
+
+        assertThatCode(() -> taskCaptor.getValue().run()).doesNotThrowAnyException();
+        verify(jobStreamStore).publishSnapshot(roomId);
+        verify(jobStreamStore, never()).publishSync(any());
+    }
+
+    @Test
+    @DisplayName("jobExecutor가 reject되면 inline으로 실행하여 publish를 시도한다")
+    void publish_whenExecutorRejects_runsInline() {
+        UUID roomId = UUID.randomUUID();
+
+        doThrow(new RuntimeException("rejected")).when(jobExecutor).execute(any(Runnable.class));
+
+        assertThatCode(() -> jobPublisher.publishSyncAsync(roomId)).doesNotThrowAnyException();
+
+        verify(jobStreamStore).publishSync(roomId);
+    }
+
+    @Test
+    @DisplayName("inline fallback 중 publish가 예외를 던져도 publishSyncAsync는 죽지 않는다")
+    void publish_whenInlinePublishThrows_doesNotCrash() {
+        UUID roomId = UUID.randomUUID();
+
+        doThrow(new RuntimeException("rejected")).when(jobExecutor).execute(any(Runnable.class));
+        doThrow(new RuntimeException("redis down")).when(jobStreamStore).publishSync(roomId);
+
+        assertThatCode(() -> jobPublisher.publishSyncAsync(roomId)).doesNotThrowAnyException();
+        verify(jobStreamStore).publishSync(roomId);
+    }
+
+    @Test
+    @DisplayName("executor 위임 경로에서 publish가 예외를 던져도 task 실행은 호출자 기준으로 제어된다(여기서는 run 시 예외 전파)")
+    void publish_taskRun_propagatesException_ifStoreThrows() {
+        UUID roomId = UUID.randomUUID();
+
+        doThrow(new RuntimeException("redis down")).when(jobStreamStore).publishSync(roomId);
+
+        jobPublisher.publishSyncAsync(roomId);
+
+        ArgumentCaptor<Runnable> taskCaptor = ArgumentCaptor.forClass(Runnable.class);
+        verify(jobExecutor).execute(taskCaptor.capture());
+
+        assertThatCode(() -> taskCaptor.getValue().run()).isInstanceOf(RuntimeException.class);
+
+        InOrder order = inOrder(jobExecutor, jobStreamStore);
+        order.verify(jobExecutor).execute(any(Runnable.class));
+        order.verify(jobStreamStore).publishSync(roomId);
+    }
+}

--- a/backend/api/src/test/java/com/yat2/episode/collaboration/worker/UpdateAppenderTest.java
+++ b/backend/api/src/test/java/com/yat2/episode/collaboration/worker/UpdateAppenderTest.java
@@ -11,6 +11,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.util.UUID;
 import java.util.concurrent.Executor;
 
+import com.yat2.episode.collaboration.config.CollaborationAsyncProperties;
 import com.yat2.episode.collaboration.redis.UpdateStreamStore;
 
 import static org.assertj.core.api.Assertions.assertThatCode;
@@ -19,6 +20,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("UpdateAppender 단위 테스트")
@@ -35,13 +37,17 @@ class UpdateAppenderTest {
 
     UpdateAppender updateAppender;
 
+    @Mock
+    CollaborationAsyncProperties asyncProperties;
+
     private static byte[] updatePayload() {
         return new byte[]{ 0, 2, 1, 2, 3, 4 };
     }
 
     @BeforeEach
     void setUp() {
-        updateAppender = new UpdateAppender(updateStreamStore, jobPublisher, updateExecutor);
+        when(asyncProperties.updateAppendMaxRetries()).thenReturn(5);
+        updateAppender = new UpdateAppender(updateStreamStore, jobPublisher, updateExecutor, asyncProperties);
     }
 
     @Test

--- a/backend/api/src/test/java/com/yat2/episode/collaboration/worker/UpdateAppenderTest.java
+++ b/backend/api/src/test/java/com/yat2/episode/collaboration/worker/UpdateAppenderTest.java
@@ -1,0 +1,118 @@
+package com.yat2.episode.collaboration.worker;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.UUID;
+import java.util.concurrent.Executor;
+
+import com.yat2.episode.collaboration.redis.UpdateStreamStore;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("UpdateAppender 단위 테스트")
+class UpdateAppenderTest {
+
+    @Mock
+    UpdateStreamStore updateStreamStore;
+
+    @Mock
+    JobPublisher jobPublisher;
+
+    @Mock
+    Executor updateExecutor;
+
+    UpdateAppender updateAppender;
+
+    private static byte[] updatePayload() {
+        return new byte[]{ 0, 2, 1, 2, 3, 4 };
+    }
+
+    @BeforeEach
+    void setUp() {
+        updateAppender = new UpdateAppender(updateStreamStore, jobPublisher, updateExecutor);
+    }
+
+    @Test
+    @DisplayName("appendUpdateAsync는 updateExecutor에 작업을 위임한다")
+    void appendUpdateAsync_delegatesToExecutor() {
+        UUID roomId = UUID.randomUUID();
+        byte[] payload = updatePayload();
+
+        updateAppender.appendUpdateAsync(roomId, payload);
+
+        ArgumentCaptor<Runnable> taskCaptor = ArgumentCaptor.forClass(Runnable.class);
+        verify(updateExecutor).execute(taskCaptor.capture());
+
+        assertThatCode(() -> taskCaptor.getValue().run()).doesNotThrowAnyException();
+        verify(updateStreamStore).appendUpdate(eq(roomId), eq(payload));
+        verify(jobPublisher, never()).publishSyncAsync(any());
+    }
+
+    @Test
+    @DisplayName("updateExecutor 스케줄링이 실패하면 publishSyncAsync로 우회한다")
+    void appendUpdateAsync_whenExecutorRejects_publishSync() {
+        UUID roomId = UUID.randomUUID();
+        byte[] payload = updatePayload();
+
+        doThrow(new RuntimeException("rejected")).when(updateExecutor).execute(any(Runnable.class));
+
+        assertThatCode(() -> updateAppender.appendUpdateAsync(roomId, payload)).doesNotThrowAnyException();
+
+        verify(jobPublisher).publishSyncAsync(roomId);
+        verify(updateStreamStore, never()).appendUpdate(any(), any());
+    }
+
+    @Test
+    @DisplayName("appendUpdate가 5회 재시도 후에도 실패하면 publishSyncAsync를 호출한다")
+    void tryAppend_whenAppendFailsFiveTimes_publishSync() {
+        UUID roomId = UUID.randomUUID();
+        byte[] payload = updatePayload();
+
+        updateAppender.appendUpdateAsync(roomId, payload);
+
+        ArgumentCaptor<Runnable> taskCaptor = ArgumentCaptor.forClass(Runnable.class);
+        verify(updateExecutor).execute(taskCaptor.capture());
+
+        doThrow(new RuntimeException("temporary")).when(updateStreamStore).appendUpdate(eq(roomId), any(byte[].class));
+
+        assertThatCode(() -> taskCaptor.getValue().run()).doesNotThrowAnyException();
+
+        verify(updateStreamStore, org.mockito.Mockito.times(5)).appendUpdate(eq(roomId), any(byte[].class));
+
+        verify(jobPublisher).publishSyncAsync(roomId);
+    }
+
+    @Test
+    @DisplayName("fatal redis write면 재시도/Sync publish 없이 종료한다")
+    void tryAppend_whenFatal_doesNotPublishSync() {
+        UUID roomId = UUID.randomUUID();
+        byte[] payload = updatePayload();
+
+        updateAppender.appendUpdateAsync(roomId, payload);
+
+        ArgumentCaptor<Runnable> taskCaptor = ArgumentCaptor.forClass(Runnable.class);
+        verify(updateExecutor).execute(taskCaptor.capture());
+
+        doThrow(new RuntimeException("OOM command not allowed when used memory > 'maxmemory'")).when(updateStreamStore)
+                .appendUpdate(eq(roomId), any(byte[].class));
+
+        assertThatCode(() -> taskCaptor.getValue().run()).doesNotThrowAnyException();
+
+        verify(updateStreamStore).appendUpdate(eq(roomId), any(byte[].class));
+        verify(updateStreamStore, org.mockito.Mockito.times(1)).appendUpdate(eq(roomId), any(byte[].class));
+
+        verify(jobPublisher, never()).publishSyncAsync(any());
+    }
+}

--- a/backend/api/src/test/java/com/yat2/episode/collaboration/yjs/YjsMessageRouterTest.java
+++ b/backend/api/src/test/java/com/yat2/episode/collaboration/yjs/YjsMessageRouterTest.java
@@ -50,11 +50,14 @@ class YjsMessageRouterTest {
     @Mock
     Executor redisExecutor;
 
+    @Mock
+    Executor jobExecutor;
+
     YjsMessageRouter router;
 
     @BeforeEach
     void setUp() {
-        router = new YjsMessageRouter(sessionRegistry, updateStreamStore, redisExecutor, jobStreamStore);
+        router = new YjsMessageRouter(sessionRegistry, updateStreamStore, redisExecutor, jobExecutor, jobStreamStore);
     }
 
     private static byte[] awarenessFrame() {

--- a/backend/api/src/test/java/com/yat2/episode/collaboration/yjs/YjsMessageRouterTest.java
+++ b/backend/api/src/test/java/com/yat2/episode/collaboration/yjs/YjsMessageRouterTest.java
@@ -47,7 +47,7 @@ class YjsMessageRouterTest {
 
     @BeforeEach
     void setUp() {
-        router = new YjsMessageRouter(sessionRegistry, jobPublisher, updateAppender);
+        router = new YjsMessageRouter(sessionRegistry, updateAppender);
     }
 
     private static byte[] awarenessFrame() {
@@ -145,7 +145,7 @@ class YjsMessageRouterTest {
         void executeSnapshot_delegatesToPublisher() {
             UUID roomId = UUID.randomUUID();
 
-            router.executeSnapshot(roomId);
+            jobPublisher.publishSnapshotAsync(roomId);
 
             verify(jobPublisher).publishSnapshotAsync(eq(roomId));
             verifyNoInteractions(updateAppender);

--- a/backend/api/src/test/java/com/yat2/episode/collaboration/yjs/YjsMessageRouterTest.java
+++ b/backend/api/src/test/java/com/yat2/episode/collaboration/yjs/YjsMessageRouterTest.java
@@ -14,19 +14,15 @@ import org.springframework.web.socket.WebSocketSession;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
-import java.util.concurrent.Executor;
 
 import com.yat2.episode.collaboration.SessionRegistry;
-import com.yat2.episode.collaboration.redis.JobStreamStore;
-import com.yat2.episode.collaboration.redis.UpdateStreamStore;
+import com.yat2.episode.collaboration.worker.JobPublisher;
+import com.yat2.episode.collaboration.worker.UpdateAppender;
 
-import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.inOrder;
-import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -42,22 +38,16 @@ class YjsMessageRouterTest {
     SessionRegistry sessionRegistry;
 
     @Mock
-    UpdateStreamStore updateStreamStore;
+    JobPublisher jobPublisher;
 
     @Mock
-    JobStreamStore jobStreamStore;
-
-    @Mock
-    Executor redisExecutor;
-
-    @Mock
-    Executor jobExecutor;
+    UpdateAppender updateAppender;
 
     YjsMessageRouter router;
 
     @BeforeEach
     void setUp() {
-        router = new YjsMessageRouter(sessionRegistry, updateStreamStore, redisExecutor, jobExecutor, jobStreamStore);
+        router = new YjsMessageRouter(sessionRegistry, jobPublisher, updateAppender);
     }
 
     private static byte[] awarenessFrame() {
@@ -98,9 +88,8 @@ class YjsMessageRouterTest {
             verify(sessionRegistry).broadcast(eq(roomId), eq(sender), captor.capture());
             assertArrayEquals(payload, captor.getValue());
 
-            verifyNoInteractions(redisExecutor);
-            verifyNoInteractions(updateStreamStore);
-            verifyNoInteractions(jobStreamStore);
+            verifyNoInteractions(updateAppender);
+            verifyNoInteractions(jobPublisher);
             verifyNoMoreInteractions(sessionRegistry);
         }
 
@@ -115,9 +104,8 @@ class YjsMessageRouterTest {
             router.routeIncoming(roomId, sender, payload);
 
             verify(sessionRegistry).broadcast(eq(roomId), eq(sender), any(byte[].class));
-            verifyNoInteractions(redisExecutor);
-            verifyNoInteractions(updateStreamStore);
-            verifyNoInteractions(jobStreamStore);
+            verifyNoInteractions(updateAppender);
+            verifyNoInteractions(jobPublisher);
         }
     }
 
@@ -126,8 +114,8 @@ class YjsMessageRouterTest {
     class UpdateTests {
 
         @Test
-        @DisplayName("Update 프레임이면 broadcast 후 Executor에 저장 task를 넣고, task 실행 시 Redis에 append한다")
-        void routeIncoming_whenUpdate_broadcastsAndAppendsAsync() {
+        @DisplayName("Update 프레임이면 broadcast 후 UpdateAppender에 appendUpdateAsync를 위임한다")
+        void routeIncoming_whenUpdate_broadcastsAndDelegatesToAppender() {
             UUID roomId = UUID.randomUUID();
             WebSocketSession sender = mock(WebSocketSession.class);
 
@@ -139,98 +127,29 @@ class YjsMessageRouterTest {
             verify(sessionRegistry).broadcast(eq(roomId), eq(sender), broadcastCaptor.capture());
             assertArrayEquals(payload, broadcastCaptor.getValue());
 
-            ArgumentCaptor<Runnable> taskCaptor = ArgumentCaptor.forClass(Runnable.class);
-            verify(redisExecutor).execute(taskCaptor.capture());
+            ArgumentCaptor<byte[]> payloadCaptor = ArgumentCaptor.forClass(byte[].class);
+            verify(updateAppender).appendUpdateAsync(eq(roomId), payloadCaptor.capture());
+            assertArrayEquals(payload, payloadCaptor.getValue());
 
-            taskCaptor.getValue().run();
-
-            ArgumentCaptor<byte[]> redisCaptor = ArgumentCaptor.forClass(byte[].class);
-            verify(updateStreamStore).appendUpdate(eq(roomId), redisCaptor.capture());
-            assertArrayEquals(payload, redisCaptor.getValue());
-
-            verify(jobStreamStore, never()).publishSync(any());
+            verifyNoInteractions(jobPublisher);
+            verifyNoMoreInteractions(sessionRegistry);
         }
+    }
+
+    @Nested
+    @DisplayName("Snapshot 트리거")
+    class SnapshotTests {
 
         @Test
-        @DisplayName("Redis append 중 예외가 발생해도 task 실행이 죽지 않고 publishSync를 시도한다")
-        void routeIncoming_whenUpdate_redisThrows_doesNotCrash_andPublishSync() {
+        @DisplayName("executeSnapshot은 JobPublisher.publishSnapshotAsync를 위임한다")
+        void executeSnapshot_delegatesToPublisher() {
             UUID roomId = UUID.randomUUID();
-            WebSocketSession sender = mock(WebSocketSession.class);
 
-            byte[] payload = updateFrame();
+            router.executeSnapshot(roomId);
 
-            doThrow(new RuntimeException("redis down")).when(updateStreamStore)
-                    .appendUpdate(eq(roomId), any(byte[].class));
-
-            assertThatCode(() -> router.routeIncoming(roomId, sender, payload)).doesNotThrowAnyException();
-
-            ArgumentCaptor<Runnable> taskCaptor = ArgumentCaptor.forClass(Runnable.class);
-            verify(redisExecutor).execute(taskCaptor.capture());
-
-            assertThatCode(() -> taskCaptor.getValue().run()).doesNotThrowAnyException();
-
-            verify(updateStreamStore).appendUpdate(eq(roomId), any(byte[].class));
-            verify(jobStreamStore).publishSync(eq(roomId));
-        }
-
-        @Test
-        @DisplayName("append 실패 후 publishSync도 예외면 task가 죽지 않는다(tryPublishSync 보호)")
-        void routeIncoming_whenUpdate_appendThrows_andPublishSyncThrows_doesNotCrash() {
-            UUID roomId = UUID.randomUUID();
-            WebSocketSession sender = mock(WebSocketSession.class);
-
-            byte[] payload = updateFrame();
-
-            doThrow(new RuntimeException("redis down")).when(updateStreamStore)
-                    .appendUpdate(eq(roomId), any(byte[].class));
-
-            doThrow(new RuntimeException("job stream down")).when(jobStreamStore).publishSync(eq(roomId));
-
-            router.routeIncoming(roomId, sender, payload);
-
-            ArgumentCaptor<Runnable> taskCaptor = ArgumentCaptor.forClass(Runnable.class);
-            verify(redisExecutor).execute(taskCaptor.capture());
-
-            assertThatCode(() -> taskCaptor.getValue().run()).doesNotThrowAnyException();
-
-            verify(updateStreamStore).appendUpdate(eq(roomId), any(byte[].class));
-            verify(jobStreamStore).publishSync(eq(roomId));
-        }
-
-        @Test
-        @DisplayName("Executor 스케줄링 자체가 실패해도 routeIncoming 흐름이 죽지 않고 publishSync를 시도한다")
-        void routeIncoming_whenExecutorThrows_doesNotCrash_andPublishSync() {
-            UUID roomId = UUID.randomUUID();
-            WebSocketSession sender = mock(WebSocketSession.class);
-
-            byte[] payload = updateFrame();
-
-            doThrow(new RuntimeException("executor rejected")).when(redisExecutor).execute(any(Runnable.class));
-
-            assertThatCode(() -> router.routeIncoming(roomId, sender, payload)).doesNotThrowAnyException();
-
-            verify(sessionRegistry).broadcast(eq(roomId), eq(sender), any(byte[].class));
-            verifyNoInteractions(updateStreamStore);
-            verify(jobStreamStore).publishSync(eq(roomId));
-        }
-
-        @Test
-        @DisplayName("Executor 스케줄 실패 후 publishSync도 실패해도 routeIncoming은 죽지 않는다")
-        void routeIncoming_whenExecutorThrows_andPublishSyncThrows_doesNotCrash() {
-            UUID roomId = UUID.randomUUID();
-            WebSocketSession sender = mock(WebSocketSession.class);
-
-            byte[] payload = updateFrame();
-
-            doThrow(new RuntimeException("executor rejected")).when(redisExecutor).execute(any(Runnable.class));
-
-            doThrow(new RuntimeException("job stream down")).when(jobStreamStore).publishSync(eq(roomId));
-
-            assertThatCode(() -> router.routeIncoming(roomId, sender, payload)).doesNotThrowAnyException();
-
-            verify(sessionRegistry).broadcast(eq(roomId), eq(sender), any(byte[].class));
-            verifyNoInteractions(updateStreamStore);
-            verify(jobStreamStore).publishSync(eq(roomId));
+            verify(jobPublisher).publishSnapshotAsync(eq(roomId));
+            verifyNoInteractions(updateAppender);
+            verifyNoInteractions(sessionRegistry);
         }
     }
 
@@ -257,9 +176,8 @@ class YjsMessageRouterTest {
             assertArrayEquals(YjsProtocolUtil.emptySync2Frame(), payloadCaptor.getValue());
 
             verify(sessionRegistry, never()).broadcast(any(), any(), any());
-            verifyNoInteractions(redisExecutor);
-            verifyNoInteractions(updateStreamStore);
-            verifyNoInteractions(jobStreamStore);
+            verifyNoInteractions(updateAppender);
+            verifyNoInteractions(jobPublisher);
         }
 
         @Test
@@ -274,11 +192,17 @@ class YjsMessageRouterTest {
             when(p1.getId()).thenReturn("P1");
 
             WebSocketSession p2 = mock(WebSocketSession.class);
+            when(p2.getId()).thenReturn("P2");
 
             when(sessionRegistry.findAllAlivePeers(roomId, "REQ")).thenReturn(new ArrayList<>(List.of(p2, p1)));
 
-            lenient().when(sessionRegistry.getConnectedAt(p1)).thenReturn(10L);
-            lenient().when(sessionRegistry.getConnectedAt(p2)).thenReturn(20L);
+            // ✅ 불필요 stubbing 방지: 한 줄 stubbing으로 connectedAt 값 제공
+            when(sessionRegistry.getConnectedAt(any(WebSocketSession.class))).thenAnswer(inv -> {
+                WebSocketSession s = inv.getArgument(0);
+                if ("P1".equals(s.getId())) return 10L;
+                if ("P2".equals(s.getId())) return 20L;
+                return 0L;
+            });
 
             byte[] sync1 = sync1Frame();
 
@@ -286,15 +210,14 @@ class YjsMessageRouterTest {
 
             router.routeIncoming(roomId, requester, sync1);
 
-            verify(sessionRegistry).findAllAlivePeers(roomId, "REQ");
             verify(sessionRegistry).unicast(roomId, "P1", sync1);
             verify(sessionRegistry, never()).unicast(eq(roomId), eq("P2"), any());
-            verify(sessionRegistry, never()).broadcast(any(), any(), any());
 
-            verifyNoInteractions(redisExecutor);
-            verifyNoInteractions(updateStreamStore);
-            verifyNoInteractions(jobStreamStore);
+            verify(sessionRegistry, never()).broadcast(any(), any(), any());
+            verifyNoInteractions(updateAppender);
+            verifyNoInteractions(jobPublisher);
         }
+
 
         @Test
         @DisplayName("Sync1에서 첫 provider unicast 실패하면 다음 provider로 넘어간다")
@@ -326,9 +249,8 @@ class YjsMessageRouterTest {
             order.verify(sessionRegistry).unicast(eq(roomId), eq("P1"), any(byte[].class));
             order.verify(sessionRegistry).unicast(eq(roomId), eq("P2"), any(byte[].class));
 
-            verifyNoInteractions(redisExecutor);
-            verifyNoInteractions(updateStreamStore);
-            verifyNoInteractions(jobStreamStore);
+            verifyNoInteractions(updateAppender);
+            verifyNoInteractions(jobPublisher);
         }
 
         @Test
@@ -343,7 +265,6 @@ class YjsMessageRouterTest {
             when(provider.getId()).thenReturn("P1");
 
             when(sessionRegistry.findAllAlivePeers(roomId, "REQ")).thenReturn(new ArrayList<>(List.of(provider)));
-
             when(sessionRegistry.unicast(eq(roomId), eq("P1"), any(byte[].class))).thenReturn(true);
 
             router.routeIncoming(roomId, requester, sync1Frame());
@@ -355,9 +276,8 @@ class YjsMessageRouterTest {
 
             verify(sessionRegistry, never()).broadcast(any(), any(), any());
 
-            verifyNoInteractions(redisExecutor);
-            verifyNoInteractions(updateStreamStore);
-            verifyNoInteractions(jobStreamStore);
+            verifyNoInteractions(updateAppender);
+            verifyNoInteractions(jobPublisher);
         }
 
         @Test
@@ -372,7 +292,6 @@ class YjsMessageRouterTest {
             when(provider.getId()).thenReturn("P1");
 
             when(sessionRegistry.findAllAlivePeers(roomId, "REQ")).thenReturn(new ArrayList<>(List.of(provider)));
-
             when(sessionRegistry.unicast(eq(roomId), eq("P1"), any(byte[].class))).thenReturn(true);
 
             router.routeIncoming(roomId, requester, sync1Frame());
@@ -383,9 +302,8 @@ class YjsMessageRouterTest {
 
             verify(sessionRegistry, never()).unicast(eq(roomId), eq("REQ"), any(byte[].class));
 
-            verifyNoInteractions(redisExecutor);
-            verifyNoInteractions(updateStreamStore);
-            verifyNoInteractions(jobStreamStore);
+            verifyNoInteractions(updateAppender);
+            verifyNoInteractions(jobPublisher);
         }
     }
 }


### PR DESCRIPTION
Closes #422

# 목적
snapshot/sync job 처리 안정성 올리기

# 작업 내용
- snapshot job publish의 경우 dedupe 처리 제외
- sync 처리 경우의 수 정리
  - update append의 executor queue에 넣으려다가 오류
    - 큐가 가득차서 abort가 났을 때
    - 알 수 없는 이유로 에러가 났을 때 -> 이 경우는 log 추가
  - update redis append가 최대 재시도 횟수만큼 실패했을 때
  - 예외
    - redis OOM 등의 fatal 오류.. => job stream, update stream 둘 다 같은 redis 인스턴스를 사용하기 때문에, sync publish 또한 처리가 불가할 것. 다른 sync 처리 방식에 대해 고민해보면 좋을 것 같은데.. 일단 이 부분은 추가적으로 생각해봐야 할 것 같아요. api 호출 방식으로 바꾼다던가.. 외부에서 트리거할 수 있는 방식을 더 고민해본다던가..
- job publisher 분리
- worker패키지로 job publisher/ update appender 계층 분리(router로부터)
- 단위 테스트

# 결과
- snapshot은 요청 중복 처리가 진행되지 않습니다.
- job publisher가 update frame 처리 thread에서 분리되었습니다.