### PR TITLE
[BE] Episode patch 처리 Date null 인 경우 삭제로 처리

### DIFF
--- a/backend/api/build.gradle
+++ b/backend/api/build.gradle
@@ -43,6 +43,8 @@ dependencies {
 
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.9'
 
+    implementation "org.openapitools:jackson-databind-nullable:0.2.8"
+
     implementation 'com.nimbusds:nimbus-jose-jwt:9.37'
     runtimeOnly 'com.mysql:mysql-connector-j'
     implementation 'org.flywaydb:flyway-mysql'

--- a/backend/api/src/main/java/com/yat2/episode/episode/EpisodeService.java
+++ b/backend/api/src/main/java/com/yat2/episode/episode/EpisodeService.java
@@ -126,12 +126,11 @@ public class EpisodeService {
         if (patch == null || patch.isUndefined()) {
             return before;
         }
-        if (!patch.isPresent()) {
+        if (!patch.isPresent() || patch.get() == null) {
             return null;
         }
         return patch.get();
     }
-
 
     private void validateCompetencyIds(Set<Integer> competencyIds) {
         if (competencyIds == null || competencyIds.isEmpty()) {

--- a/backend/api/src/main/java/com/yat2/episode/episode/EpisodeStar.java
+++ b/backend/api/src/main/java/com/yat2/episode/episode/EpisodeStar.java
@@ -13,6 +13,7 @@ import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.openapitools.jackson.nullable.JsonNullable;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
@@ -87,13 +88,22 @@ public class EpisodeStar {
         if (req.task() != null) this.task = req.task();
         if (req.action() != null) this.action = req.action();
         if (req.result() != null) this.result = req.result();
-        if (req.startDate() != null) this.startDate = req.startDate();
-        if (req.endDate() != null) this.endDate = req.endDate();
+        applyDatePatch(req.startDate(), d -> this.startDate = d);
+        applyDatePatch(req.endDate(), d -> this.endDate = d);
 
         if (req.competencyTypeIds() != null) {
             this.competencyTypeIds.clear();
             this.competencyTypeIds.addAll(req.competencyTypeIds());
         }
+    }
+
+    private void applyDatePatch(JsonNullable<LocalDate> patch, java.util.function.Consumer<LocalDate> setter) {
+        if (patch == null || patch.isUndefined()) return;
+        if (!patch.isPresent()) {
+            setter.accept(null);
+            return;
+        }
+        setter.accept(patch.get());
     }
 
     public void clearDates() {

--- a/backend/api/src/main/java/com/yat2/episode/episode/dto/StarUpdateReq.java
+++ b/backend/api/src/main/java/com/yat2/episode/episode/dto/StarUpdateReq.java
@@ -2,6 +2,7 @@ package com.yat2.episode.episode.dto;
 
 import jakarta.validation.constraints.Positive;
 import jakarta.validation.constraints.Size;
+import org.openapitools.jackson.nullable.JsonNullable;
 
 import java.time.LocalDate;
 import java.util.Set;
@@ -12,6 +13,6 @@ public record StarUpdateReq(
         @Size(max = 200) String task,
         @Size(max = 200) String action,
         @Size(max = 200) String result,
-        LocalDate startDate,
-        LocalDate endDate
+        JsonNullable<LocalDate> startDate,
+        JsonNullable<LocalDate> endDate
 ) {}

--- a/backend/api/src/main/java/com/yat2/episode/global/config/JacksonConfig.java
+++ b/backend/api/src/main/java/com/yat2/episode/global/config/JacksonConfig.java
@@ -1,0 +1,14 @@
+package com.yat2.episode.global.config;
+
+import org.openapitools.jackson.nullable.JsonNullableModule;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class JacksonConfig {
+
+    @Bean
+    public JsonNullableModule jsonNullableModule() {
+        return new JsonNullableModule();
+    }
+}

--- a/backend/api/src/test/java/com/yat2/episode/episode/EpisodeServiceTest.java
+++ b/backend/api/src/test/java/com/yat2/episode/episode/EpisodeServiceTest.java
@@ -8,6 +8,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.openapitools.jackson.nullable.JsonNullable;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -139,8 +141,12 @@ class EpisodeServiceTest {
         @Test
         @DisplayName("STAR 업데이트 실패: 날짜 순서가 잘못되면 INVALID_REQUEST")
         void updateStar_DateInvalid() {
+            EpisodeStar star = EpisodeStar.create(nodeId, userId);
+            when(episodeStarRepository.findById(any(EpisodeId.class))).thenReturn(Optional.of(star));
+
             StarUpdateReq req =
-                    new StarUpdateReq(null, null, null, null, null, LocalDate.now().plusDays(1), LocalDate.now());
+                    new StarUpdateReq(null, null, null, null, null, JsonNullable.of(LocalDate.now().plusDays(1)),
+                                      JsonNullable.of(LocalDate.now()));
 
             assertThatThrownBy(() -> episodeService.updateStar(nodeId, userId, req)).isInstanceOf(CustomException.class)
                     .hasFieldOrPropertyWithValue("errorCode", ErrorCode.INVALID_REQUEST);
@@ -170,5 +176,47 @@ class EpisodeServiceTest {
 
             verify(episodeRepository).deleteById(nodeId);
         }
+
+        @Test
+        @DisplayName("STAR PATCH: startDate를 null로 보내면 startDate가 삭제(null)되어야 한다")
+        void updateStar_ClearStartDate_WithNull() {
+            EpisodeStar star = EpisodeStar.create(nodeId, userId);
+
+            org.springframework.test.util.ReflectionTestUtils.setField(star, "startDate", LocalDate.now());
+            org.springframework.test.util.ReflectionTestUtils.setField(star, "endDate", LocalDate.now().plusDays(1));
+
+            when(episodeStarRepository.findById(any(EpisodeId.class))).thenReturn(Optional.of(star));
+
+            StarUpdateReq req = new StarUpdateReq(null, null, null, null, null, JsonNullable.<LocalDate>of(null),
+                                                  JsonNullable.undefined());
+
+            episodeService.updateStar(nodeId, userId, req);
+
+            assertThat(star.getStartDate()).isNull();
+            assertThat(star.getEndDate()).isEqualTo(LocalDate.now().plusDays(1)); // 기존 유지
+        }
+
+
+        @Test
+        @DisplayName("STAR PATCH: startDate 필드가 없으면(undefined) 기존 startDate는 유지되어야 한다")
+        void updateStar_StartDateAbsent_ShouldNotChange() {
+            EpisodeStar star = EpisodeStar.create(nodeId, userId);
+
+            LocalDate beforeStart = LocalDate.now();
+            LocalDate beforeEnd = LocalDate.now().plusDays(1);
+            ReflectionTestUtils.setField(star, "startDate", beforeStart);
+            ReflectionTestUtils.setField(star, "endDate", beforeEnd);
+
+            when(episodeStarRepository.findById(any(EpisodeId.class))).thenReturn(Optional.of(star));
+
+            StarUpdateReq req =
+                    new StarUpdateReq(null, null, null, null, null, JsonNullable.undefined(), JsonNullable.undefined());
+
+            episodeService.updateStar(nodeId, userId, req);
+
+            assertThat(star.getStartDate()).isEqualTo(beforeStart);
+            assertThat(star.getEndDate()).isEqualTo(beforeEnd);
+        }
+
     }
 }

--- a/backend/api/src/test/java/com/yat2/episode/global/config/JacksonConfigTest.java
+++ b/backend/api/src/test/java/com/yat2/episode/global/config/JacksonConfigTest.java
@@ -1,0 +1,33 @@
+package com.yat2.episode.global.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.junit.jupiter.api.Test;
+import org.openapitools.jackson.nullable.JsonNullableModule;
+
+import java.time.LocalDate;
+
+import com.yat2.episode.episode.dto.StarUpdateReq;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class JacksonConfigTest {
+
+    @Test
+    void jsonNullable_distinguishes_absent_vs_null_vs_value() throws Exception {
+        ObjectMapper om = new ObjectMapper();
+        om.registerModule(new JsonNullableModule());
+        om.registerModule(new JavaTimeModule());
+
+        StarUpdateReq absent = om.readValue("{}", StarUpdateReq.class);
+        assertThat(absent.startDate().isUndefined()).isTrue();
+
+        StarUpdateReq nul = om.readValue("{\"startDate\":null}", StarUpdateReq.class);
+        assertThat(nul.startDate().isUndefined()).isFalse();
+        assertThat(nul.startDate().get()).isNull();
+
+        StarUpdateReq val = om.readValue("{\"startDate\":\"2026-02-18\"}", StarUpdateReq.class);
+        assertThat(val.startDate().isUndefined()).isFalse();
+        assertThat(val.startDate().get()).isEqualTo(LocalDate.parse("2026-02-18"));
+    }
+}

--- a/backend/api/src/test/java/com/yat2/episode/utils/TestEntityFactory.java
+++ b/backend/api/src/test/java/com/yat2/episode/utils/TestEntityFactory.java
@@ -1,6 +1,7 @@
 package com.yat2.episode.utils;
 
 import com.github.f4b6a3.uuid.UuidCreator;
+import org.openapitools.jackson.nullable.JsonNullable;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.lang.reflect.Constructor;
@@ -69,8 +70,10 @@ public class TestEntityFactory {
 
     public static EpisodeStar createEpisodeStar(UUID nodeId, long userId, Set<Integer> competencyTypeIds) {
         EpisodeStar star = EpisodeStar.create(nodeId, userId);
-        star.update(new StarUpdateReq(competencyTypeIds, "situation", "task", "action", "result", LocalDate.now(),
-                                      LocalDate.now().plusDays(1)));
+
+        star.update(new StarUpdateReq(competencyTypeIds, "situation", "task", "action", "result",
+                                      JsonNullable.of(LocalDate.now()), JsonNullable.of(LocalDate.now().plusDays(1))));
+
         ReflectionTestUtils.setField(star, "createdAt", LocalDateTime.now());
         return star;
     }


### PR DESCRIPTION
Closes #427

# 목적
episode 수정에 대해서, date 삭제만 api를 따로 보내야하는 번거로움을 줄이고 api를 하나로 처리할 수 있도록 개선

# 작업 내용
date 값으로 null을 넣으면 삭제, 아예 인자가 없으면 업데이트 x

# 결과

