### PR TITLE
[BE] competency type id만 응답 -> competency name 데이터 포함 응답

### DIFF
--- a/backend/api/src/main/java/com/yat2/episode/competency/CompetencyTypeService.java
+++ b/backend/api/src/main/java/com/yat2/episode/competency/CompetencyTypeService.java
@@ -18,7 +18,8 @@ public class CompetencyTypeService {
     }
 
     public List<CompetencyTypeRes> getCompetencyTypesInIds(Iterable<Integer> ids) {
-        return competencyTypeRepository.findAllById(ids).stream().map(CompetencyTypeRes::of).toList();
+        return competencyTypeRepository.findAllById(ids).stream().map(CompetencyTypeRes::of)
+                .sorted(java.util.Comparator.comparing(CompetencyTypeRes::id)).toList();
     }
 
     public long countByIdIn(Set<Integer> ids) {

--- a/backend/api/src/main/java/com/yat2/episode/competency/CompetencyTypeService.java
+++ b/backend/api/src/main/java/com/yat2/episode/competency/CompetencyTypeService.java
@@ -17,7 +17,7 @@ public class CompetencyTypeService {
         return competencyTypeRepository.findAll().stream().map(CompetencyTypeRes::of).toList();
     }
 
-    public List<CompetencyTypeRes> getCompetencyTypesInIds(Set<Integer> ids) {
+    public List<CompetencyTypeRes> getCompetencyTypesInIds(Iterable<Integer> ids) {
         return competencyTypeRepository.findAllById(ids).stream().map(CompetencyTypeRes::of).toList();
     }
 

--- a/backend/api/src/main/java/com/yat2/episode/competency/CompetencyTypeService.java
+++ b/backend/api/src/main/java/com/yat2/episode/competency/CompetencyTypeService.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Set;
 
 import com.yat2.episode.competency.dto.CompetencyTypeRes;
 
@@ -14,5 +15,13 @@ public class CompetencyTypeService {
 
     public List<CompetencyTypeRes> getAllData() {
         return competencyTypeRepository.findAll().stream().map(CompetencyTypeRes::of).toList();
+    }
+
+    public List<CompetencyTypeRes> getCompetencyTypesInIds(Set<Integer> ids) {
+        return competencyTypeRepository.findAllById(ids).stream().map(CompetencyTypeRes::of).toList();
+    }
+
+    public long countByIdIn(Set<Integer> ids) {
+        return competencyTypeRepository.countByIdIn(ids);
     }
 }

--- a/backend/api/src/main/java/com/yat2/episode/episode/EpisodeService.java
+++ b/backend/api/src/main/java/com/yat2/episode/episode/EpisodeService.java
@@ -63,10 +63,7 @@ public class EpisodeService {
                 .orElseThrow(() -> new CustomException(ErrorCode.EPISODE_STAR_NOT_FOUND));
         episode.update(episodeUpsertReq);
 
-        List<CompetencyTypeRes> ctResList =
-                competencyTypeService.getCompetencyTypesInIds(episodeStar.getCompetencyTypeIds());
-
-        return EpisodeDetail.of(episode, episodeStar, ctResList);
+        return buildEpisodeDetail(episode, episodeStar);
     }
 
     @Transactional
@@ -100,9 +97,12 @@ public class EpisodeService {
     private EpisodeDetail getEpisodeAndStarOrThrow(UUID nodeId, long userId) {
         EpisodeStar s = episodeStarRepository.findStarDetail(nodeId, userId)
                 .orElseThrow(() -> new CustomException(ErrorCode.EPISODE_NOT_FOUND));
-        List<CompetencyTypeRes> ctResList = competencyTypeService.getCompetencyTypesInIds(s.getCompetencyTypeIds());
+        return buildEpisodeDetail(s.getEpisode(), s);
+    }
 
-        return EpisodeDetail.of(s.getEpisode(), s, ctResList);
+    private EpisodeDetail buildEpisodeDetail(Episode episode, EpisodeStar star) {
+        List<CompetencyTypeRes> ctResList = competencyTypeService.getCompetencyTypesInIds(star.getCompetencyTypeIds());
+        return EpisodeDetail.of(episode, star, ctResList);
     }
 
     private EpisodeStar getStarOrThrow(UUID nodeId, long userId) {

--- a/backend/api/src/main/java/com/yat2/episode/episode/EpisodeService.java
+++ b/backend/api/src/main/java/com/yat2/episode/episode/EpisodeService.java
@@ -9,7 +9,8 @@ import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 
-import com.yat2.episode.competency.CompetencyTypeRepository;
+import com.yat2.episode.competency.CompetencyTypeService;
+import com.yat2.episode.competency.dto.CompetencyTypeRes;
 import com.yat2.episode.episode.dto.EpisodeDetail;
 import com.yat2.episode.episode.dto.EpisodeSummaryRes;
 import com.yat2.episode.episode.dto.EpisodeUpsertContentReq;
@@ -26,7 +27,7 @@ import com.yat2.episode.mindmap.MindmapParticipantRepository;
 public class EpisodeService {
 
     private final EpisodeRepository episodeRepository;
-    private final CompetencyTypeRepository competencyTypeRepository;
+    private final CompetencyTypeService competencyTypeService;
     private final EpisodeStarRepository episodeStarRepository;
     private final MindmapAccessValidator mindmapAccessValidator;
     private final MindmapParticipantRepository mindmapParticipantRepository;
@@ -62,7 +63,10 @@ public class EpisodeService {
                 .orElseThrow(() -> new CustomException(ErrorCode.EPISODE_STAR_NOT_FOUND));
         episode.update(episodeUpsertReq);
 
-        return EpisodeDetail.of(episode, episodeStar);
+        List<CompetencyTypeRes> ctResList =
+                competencyTypeService.getCompetencyTypesInIds(episodeStar.getCompetencyTypeIds());
+
+        return EpisodeDetail.of(episode, episodeStar, ctResList);
     }
 
     @Transactional
@@ -96,8 +100,9 @@ public class EpisodeService {
     private EpisodeDetail getEpisodeAndStarOrThrow(UUID nodeId, long userId) {
         EpisodeStar s = episodeStarRepository.findStarDetail(nodeId, userId)
                 .orElseThrow(() -> new CustomException(ErrorCode.EPISODE_NOT_FOUND));
+        List<CompetencyTypeRes> ctResList = competencyTypeService.getCompetencyTypesInIds(s.getCompetencyTypeIds());
 
-        return EpisodeDetail.of(s.getEpisode(), s);
+        return EpisodeDetail.of(s.getEpisode(), s, ctResList);
     }
 
     private EpisodeStar getStarOrThrow(UUID nodeId, long userId) {
@@ -123,7 +128,7 @@ public class EpisodeService {
             return;
         }
 
-        long count = competencyTypeRepository.countByIdIn(competencyIds);
+        long count = competencyTypeService.countByIdIn(competencyIds);
         if (count != competencyIds.size()) {
             throw new CustomException(ErrorCode.INVALID_COMPETENCY_TYPE);
         }

--- a/backend/api/src/main/java/com/yat2/episode/episode/dto/EpisodeDetail.java
+++ b/backend/api/src/main/java/com/yat2/episode/episode/dto/EpisodeDetail.java
@@ -5,13 +5,14 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
 
+import com.yat2.episode.competency.dto.CompetencyTypeRes;
 import com.yat2.episode.episode.Episode;
 import com.yat2.episode.episode.EpisodeStar;
 
 public record EpisodeDetail(
         UUID nodeId,
         UUID mindmapId,
-        List<Integer> competencyTypeIds,
+        List<CompetencyTypeRes> competencyTypes,
         String content,
         String situation,
         String task,
@@ -23,18 +24,16 @@ public record EpisodeDetail(
         LocalDateTime updatedAt
 ) {
     public EpisodeDetail {
-        competencyTypeIds = (competencyTypeIds == null) ? List.of() : List.copyOf(competencyTypeIds);
+        competencyTypes = (competencyTypes == null) ? List.of() : List.copyOf(competencyTypes);
     }
 
-    public static EpisodeDetail of(Episode e, EpisodeStar s) {
+    public static EpisodeDetail of(Episode e, EpisodeStar s, List<CompetencyTypeRes> cts) {
         if (s == null) {
             return new EpisodeDetail(e.getId(), e.getMindmapId(), List.of(), e.getContent(), null, null, null, null,
                                      null, null, null, null);
         }
 
-        List<Integer> ctIds = s.getCompetencyTypeIds().stream().sorted().toList();
-
-        return new EpisodeDetail(e.getId(), e.getMindmapId(), ctIds, e.getContent(), s.getSituation(), s.getTask(),
+        return new EpisodeDetail(e.getId(), e.getMindmapId(), cts, e.getContent(), s.getSituation(), s.getTask(),
                                  s.getAction(), s.getResult(), s.getStartDate(), s.getEndDate(), s.getCreatedAt(),
                                  s.getUpdatedAt());
     }

--- a/backend/api/src/main/java/com/yat2/episode/mindmap/MindmapController.java
+++ b/backend/api/src/main/java/com/yat2/episode/mindmap/MindmapController.java
@@ -25,6 +25,7 @@ import java.net.URI;
 import java.util.List;
 import java.util.UUID;
 
+import com.yat2.episode.competency.dto.CompetencyTypeRes;
 import com.yat2.episode.global.exception.ErrorCode;
 import com.yat2.episode.global.swagger.ApiErrorCodes;
 import com.yat2.episode.global.swagger.AuthRequiredErrors;
@@ -205,7 +206,7 @@ public class MindmapController {
     @AuthRequiredErrors
     @ApiErrorCodes({ ErrorCode.INVALID_REQUEST, ErrorCode.INTERNAL_ERROR, ErrorCode.MINDMAP_NOT_FOUND })
     @GetMapping("/{mindmapId}/competency-types")
-    public List<Integer> getCompetenciesInMindmap(
+    public List<CompetencyTypeRes> getCompetenciesInMindmap(
             @RequestAttribute(USER_ID) long userId,
             @PathVariable UUID mindmapId
     ) {

--- a/backend/api/src/main/java/com/yat2/episode/mindmap/MindmapService.java
+++ b/backend/api/src/main/java/com/yat2/episode/mindmap/MindmapService.java
@@ -11,6 +11,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 
+import com.yat2.episode.competency.CompetencyTypeService;
+import com.yat2.episode.competency.dto.CompetencyTypeRes;
 import com.yat2.episode.episode.EpisodeRepository;
 import com.yat2.episode.episode.EpisodeStar;
 import com.yat2.episode.episode.EpisodeStarRepository;
@@ -43,11 +45,13 @@ public class MindmapService {
     private final MindmapJwtProvider mindmapJwtProvider;
     private final EpisodeRepository episodeRepository;
     private final EpisodeStarRepository episodeStarRepository;
+    private final CompetencyTypeService competencyTypeService;
 
     public MindmapDetailRes getMindmapById(Long userId, UUID mindmapId) {
         MindmapParticipant p = mindmapAccessValidator.findParticipantOrThrow(mindmapId, userId);
         List<Integer> competencyTypeIds = getSortedCompetencyTypeIds(mindmapId, userId);
-        return MindmapDetailRes.of(p, competencyTypeIds);
+        List<CompetencyTypeRes> ctResList = competencyTypeService.getCompetencyTypesInIds(competencyTypeIds);
+        return MindmapDetailRes.of(p, ctResList);
     }
 
     public List<MindmapDetailRes> getMindmaps(Long userId, MindmapVisibility type) {
@@ -71,7 +75,8 @@ public class MindmapService {
         return participants.stream().map(p -> {
             UUID id = p.getMindmap().getId();
             List<Integer> ids = competencyMap.getOrDefault(id, Set.of()).stream().sorted().toList();
-            return MindmapDetailRes.of(p, ids);
+            List<CompetencyTypeRes> ctResList = competencyTypeService.getCompetencyTypesInIds(ids);
+            return MindmapDetailRes.of(p, ctResList);
         }).toList();
     }
 

--- a/backend/api/src/main/java/com/yat2/episode/mindmap/MindmapService.java
+++ b/backend/api/src/main/java/com/yat2/episode/mindmap/MindmapService.java
@@ -209,12 +209,14 @@ public class MindmapService {
         return new MindmapSessionJoinRes(ticket, presignedUrl);
     }
 
-    public List<Integer> getCompetencyTypesInMindmap(UUID mindmapId, long userId) {
+    public List<CompetencyTypeRes> getCompetencyTypesInMindmap(UUID mindmapId, long userId) {
         mindmapAccessValidator.findParticipantOrThrow(mindmapId, userId);
-        return getSortedCompetencyTypeIds(mindmapId, userId);
+        List<Integer> ids = getSortedCompetencyTypeIds(mindmapId, userId);
+        return competencyTypeService.getCompetencyTypesInIds(ids);
     }
 
     private List<Integer> getSortedCompetencyTypeIds(UUID mindmapId, long userId) {
         return episodeStarRepository.findCompetencyTypesByMindmapId(mindmapId, userId).stream().sorted().toList();
     }
+
 }

--- a/backend/api/src/main/java/com/yat2/episode/mindmap/dto/response/MindmapDetailRes.java
+++ b/backend/api/src/main/java/com/yat2/episode/mindmap/dto/response/MindmapDetailRes.java
@@ -4,6 +4,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
 
+import com.yat2.episode.competency.dto.CompetencyTypeRes;
 import com.yat2.episode.mindmap.MindmapParticipant;
 
 public record MindmapDetailRes(
@@ -11,14 +12,14 @@ public record MindmapDetailRes(
         String mindmapName,
         boolean isFavorite,
         boolean isShared,
-        List<Integer> competencyTypeIds,
+        List<CompetencyTypeRes> competencyTypes,
         LocalDateTime createdAt,
         LocalDateTime updatedAt
 ) {
-    public static MindmapDetailRes of(MindmapParticipant mindmapParticipant, List<Integer> competencyTypeIds) {
+    public static MindmapDetailRes of(MindmapParticipant mindmapParticipant, List<CompetencyTypeRes> competencyTypes) {
         return new MindmapDetailRes(mindmapParticipant.getMindmap().getId(), mindmapParticipant.getMindmap().getName(),
                                     mindmapParticipant.isFavorite(), mindmapParticipant.getMindmap().isShared(),
-                                    competencyTypeIds, mindmapParticipant.getMindmap().getCreatedAt(),
+                                    competencyTypes, mindmapParticipant.getMindmap().getCreatedAt(),
                                     mindmapParticipant.getMindmap().getUpdatedAt());
     }
 }

--- a/backend/api/src/test/java/com/yat2/episode/episode/EpisodeServiceTest.java
+++ b/backend/api/src/test/java/com/yat2/episode/episode/EpisodeServiceTest.java
@@ -14,6 +14,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
+import com.yat2.episode.competency.CompetencyTypeService;
 import com.yat2.episode.episode.dto.EpisodeDetail;
 import com.yat2.episode.episode.dto.EpisodeUpsertContentReq;
 import com.yat2.episode.episode.dto.StarUpdateReq;
@@ -46,6 +47,8 @@ class EpisodeServiceTest {
     private MindmapAccessValidator mindmapAccessValidator;
     @Mock
     private MindmapParticipantRepository mindmapParticipantRepository;
+    @Mock
+    private CompetencyTypeService competencyTypeService;
 
     private UUID nodeId;
     private UUID mindmapId;
@@ -68,7 +71,6 @@ class EpisodeServiceTest {
             Episode episode = Episode.create(nodeId, mindmapId);
             EpisodeStar star = EpisodeStar.create(nodeId, userId);
 
-            // EpisodeStar 내부 episode 필드는 보통 JPA가 채우지만, 단위 테스트에선 직접 주입이 어려우니 spy/mock로 처리
             EpisodeStar spyStar = org.mockito.Mockito.spy(star);
             when(spyStar.getEpisode()).thenReturn(episode);
 


### PR DESCRIPTION
Closes #429

# 목적
역량 id로 프론트에 전해줘서, 따로 매핑 처리해야하는 부담을 줄이기 위함.

# 작업 내용
- 역량 id list로 주던 것을 아래 json 형태 리스트로 반환합니다.
- 반환 값의 key는 competencyTypes 입니다.
```
  "id": 0,
  "category": "협업_커뮤니케이션_역량",
  "competencyType": "string"
```

# 결과
<img width="1039" height="464" alt="image" src="https://github.com/user-attachments/assets/bcd78c94-7607-4f75-af4f-307042a47d04" />

<img width="1023" height="603" alt="image" src="https://github.com/user-attachments/assets/eab8cad6-b61c-41a4-b4ad-203faac0316e" />

<img width="996" height="646" alt="image" src="https://github.com/user-attachments/assets/4e5e251e-f754-4664-b6be-1de153bd97b9" />



