### PR TITLE
[BE] 서버 Sync2 응답 포맷 수정

### DIFF
--- a/backend/api/src/main/java/com/yat2/episode/collaboration/yjs/YjsProtocolUtil.java
+++ b/backend/api/src/main/java/com/yat2/episode/collaboration/yjs/YjsProtocolUtil.java
@@ -31,7 +31,7 @@ public class YjsProtocolUtil {
     }
 
     public static byte[] emptySync2Frame() {
-        return new byte[]{ (byte) MSG_SYNC, (byte) SYNC_STEP_2, 0x00 };
+        return new byte[]{ (byte) MSG_SYNC, (byte) SYNC_STEP_2, 0x02, 0x00, 0x00 };
     }
 
     private static boolean hasPrefix(byte[] payload, int b0, int b1) {

--- a/backend/api/src/main/java/com/yat2/episode/collaboration/yjs/YjsProtocolUtil.java
+++ b/backend/api/src/main/java/com/yat2/episode/collaboration/yjs/YjsProtocolUtil.java
@@ -11,6 +11,9 @@ public class YjsProtocolUtil {
     public static final int SYNC_STEP_2 = 1;
     public static final int SYNC_UPDATE = 2;
 
+    private static final byte[] EMPTY_SYNC_2_FRAME =
+            new byte[]{ (byte) MSG_SYNC, (byte) SYNC_STEP_2, 0x02, 0x00, 0x00 };
+
     public static boolean isUpdateFrame(byte[] payload) {
         return hasPrefix(payload, MSG_SYNC, SYNC_UPDATE);
     }
@@ -31,7 +34,7 @@ public class YjsProtocolUtil {
     }
 
     public static byte[] emptySync2Frame() {
-        return new byte[]{ (byte) MSG_SYNC, (byte) SYNC_STEP_2, 0x02, 0x00, 0x00 };
+        return EMPTY_SYNC_2_FRAME;
     }
 
     private static boolean hasPrefix(byte[] payload, int b0, int b1) {


### PR DESCRIPTION
# 목적
y-websocket이 서버의 sync2 응답을 에러로 처리하는 문제 해결
# 작업 내용
0x00 0x01 0x00에서
0x00 0x01 0x02 0x00 0x00으로 수정
