### PR TITLE
[BE] Yjs runner SYNC 처리 구현

### DIFF
--- a/backend/yjs-runner/.prettierrc.json5
+++ b/backend/yjs-runner/.prettierrc.json5
@@ -1,0 +1,10 @@
+{
+    tabWidth: 4, // 탭 너비
+    arrowParens: "always", // 화살표 함수 인자 하나여도 괄호 쓰기
+    jsxSingleQuote: false, // JSX에 single 쿼테이션 사용 여부
+    printWidth: 120, // 줄 바꿈 할 폭 길이
+    semi: true, // 세미콜론 사용 여부
+    proseWrap: "preserve", // markdown 텍스트의 줄바꿈 방식 (v1.8.2)
+    quoteProps: "as-needed", // 객체 속성에 쿼테이션 적용 방식
+    trailingComma: "all", // 여러 줄을 사용할 때, 후행 콤마 사용 방식
+}

--- a/backend/yjs-runner/app/src/contracts/Job.ts
+++ b/backend/yjs-runner/app/src/contracts/Job.ts
@@ -5,5 +5,6 @@ export type Job = {
 };
 
 export enum JobType {
-    SNAPSHOT = 'SNAPSHOT', SYNC = 'SYNC'
+    SNAPSHOT = "SNAPSHOT",
+    SYNC = "SYNC",
 }

--- a/backend/yjs-runner/app/src/contracts/StreamPendingEntries.ts
+++ b/backend/yjs-runner/app/src/contracts/StreamPendingEntries.ts
@@ -1,8 +1,3 @@
-export type StreamPendingEntry = [
-    entryId: string,
-    consumer: string,
-    idleMs: number,
-    deliveryCount: number
-];
+export type StreamPendingEntry = [entryId: string, consumer: string, idleMs: number, deliveryCount: number];
 
 export type StreamPendingEntries = StreamPendingEntry[];

--- a/backend/yjs-runner/app/src/domain/YjsProcessor.ts
+++ b/backend/yjs-runner/app/src/domain/YjsProcessor.ts
@@ -1,64 +1,47 @@
 import * as Y from "yjs";
 
 export interface YjsProcessor {
-	buildUpdatedSnapshot(
-		baseSnapshot: Uint8Array,
-		updates: Uint8Array[],
-	): Uint8Array;
+    buildUpdatedSnapshot(baseSnapshot: Uint8Array, updates: Uint8Array[]): Uint8Array;
 
-	getUpdatedYDocFromSnapshot(
-		baseSnapshot: Uint8Array,
-		updates: Uint8Array[],
-	): Y.Doc;
+    getUpdatedYDocFromSnapshot(baseSnapshot: Uint8Array, updates: Uint8Array[]): Y.Doc;
 
-	getSnapshotFromDoc(doc: Y.Doc): Uint8Array;
+    getSnapshotFromDoc(doc: Y.Doc): Uint8Array;
 }
 
 export class DefaultYjsProcessor implements YjsProcessor {
-	buildUpdatedSnapshot(
-		baseSnapshot: Uint8Array,
-		updates: Uint8Array[],
-	): Uint8Array {
-		return Y.encodeStateAsUpdate(
-			this.getUpdatedYDocFromSnapshot(baseSnapshot, updates),
-		);
-	}
+    buildUpdatedSnapshot(baseSnapshot: Uint8Array, updates: Uint8Array[]): Uint8Array {
+        return Y.encodeStateAsUpdate(this.getUpdatedYDocFromSnapshot(baseSnapshot, updates));
+    }
 
-	getUpdatedYDocFromSnapshot(
-		baseSnapshot: Uint8Array,
-		updates: Uint8Array[],
-	): Y.Doc {
-		let doc = new Y.Doc();
+    getUpdatedYDocFromSnapshot(baseSnapshot: Uint8Array, updates: Uint8Array[]): Y.Doc {
+        let doc = new Y.Doc();
 
-		if (baseSnapshot && baseSnapshot.length > 0) {
-			try {
-				Y.applyUpdate(doc, baseSnapshot);
-			} catch (e) {
-				console.error(
-					"[YjsProcessor] 기존 base snapshot 데이터가 유효하지 않습니다.",
-					e,
-				);
-				doc = new Y.Doc();
-			}
-		}
+        if (baseSnapshot && baseSnapshot.length > 0) {
+            try {
+                Y.applyUpdate(doc, baseSnapshot);
+            } catch (e) {
+                console.error("[YjsProcessor] 기존 base snapshot 데이터가 유효하지 않습니다.", e);
+                doc = new Y.Doc();
+            }
+        }
 
-		for (const update of updates) {
-			try {
-				Y.applyUpdate(doc, update);
-			} catch (e) {
-				console.error("[YjsProcessor] 업데이트 패킷이 유효하지 않습니다.", e);
-			}
-		}
+        for (const update of updates) {
+            try {
+                Y.applyUpdate(doc, update);
+            } catch (e) {
+                console.error("[YjsProcessor] 업데이트 패킷이 유효하지 않습니다.", e);
+            }
+        }
 
-		return doc;
-	}
+        return doc;
+    }
 
-	getSnapshotFromDoc(doc: Y.Doc): Uint8Array {
-		try {
-			return Y.encodeStateAsUpdate(doc);
-		} catch (e) {
-			console.error("[YjsProcessor] 유효하지 않은 YDoc 입니다.", e);
-			throw e;
-		}
-	}
+    getSnapshotFromDoc(doc: Y.Doc): Uint8Array {
+        try {
+            return Y.encodeStateAsUpdate(doc);
+        } catch (e) {
+            console.error("[YjsProcessor] 유효하지 않은 YDoc 입니다.", e);
+            throw e;
+        }
+    }
 }

--- a/backend/yjs-runner/app/src/domain/YjsProcessor.ts
+++ b/backend/yjs-runner/app/src/domain/YjsProcessor.ts
@@ -1,30 +1,64 @@
-import * as Y from 'yjs';
+import * as Y from "yjs";
 
 export interface YjsProcessor {
-    buildSnapshot(baseSnapshot: Uint8Array, updates: Uint8Array[]): Uint8Array;
+	buildUpdatedSnapshot(
+		baseSnapshot: Uint8Array,
+		updates: Uint8Array[],
+	): Uint8Array;
+
+	getUpdatedYDocFromSnapshot(
+		baseSnapshot: Uint8Array,
+		updates: Uint8Array[],
+	): Y.Doc;
+
+	getSnapshotFromDoc(doc: Y.Doc): Uint8Array;
 }
 
 export class DefaultYjsProcessor implements YjsProcessor {
-    buildSnapshot(baseSnapshot: Uint8Array, updates: Uint8Array[]): Uint8Array {
-        let doc = new Y.Doc();
+	buildUpdatedSnapshot(
+		baseSnapshot: Uint8Array,
+		updates: Uint8Array[],
+	): Uint8Array {
+		return Y.encodeStateAsUpdate(
+			this.getUpdatedYDocFromSnapshot(baseSnapshot, updates),
+		);
+	}
 
-        if (baseSnapshot && baseSnapshot.length > 0) {
-            try {
-                Y.applyUpdate(doc, baseSnapshot);
-            } catch (e) {
-                console.error('[YjsProcessor] 기존 base snapshot 데이터가 유효하지 않습니다.', e);
-                doc = new Y.Doc();
-            }
-        }
+	getUpdatedYDocFromSnapshot(
+		baseSnapshot: Uint8Array,
+		updates: Uint8Array[],
+	): Y.Doc {
+		let doc = new Y.Doc();
 
-        for (const update of updates) {
-            try {
-                Y.applyUpdate(doc, update);
-            } catch (e) {
-                console.error('[YjsProcessor] 업데이트 패킷이 유효하지 않습니다.', e);
-            }
-        }
+		if (baseSnapshot && baseSnapshot.length > 0) {
+			try {
+				Y.applyUpdate(doc, baseSnapshot);
+			} catch (e) {
+				console.error(
+					"[YjsProcessor] 기존 base snapshot 데이터가 유효하지 않습니다.",
+					e,
+				);
+				doc = new Y.Doc();
+			}
+		}
 
-        return Y.encodeStateAsUpdate(doc);
-    }
+		for (const update of updates) {
+			try {
+				Y.applyUpdate(doc, update);
+			} catch (e) {
+				console.error("[YjsProcessor] 업데이트 패킷이 유효하지 않습니다.", e);
+			}
+		}
+
+		return doc;
+	}
+
+	getSnapshotFromDoc(doc: Y.Doc): Uint8Array {
+		try {
+			return Y.encodeStateAsUpdate(doc);
+		} catch (e) {
+			console.error("[YjsProcessor] 유효하지 않은 YDoc 입니다.", e);
+			throw e;
+		}
+	}
 }

--- a/backend/yjs-runner/app/src/infrastructure/JobConsumer.ts
+++ b/backend/yjs-runner/app/src/infrastructure/JobConsumer.ts
@@ -1,180 +1,201 @@
-import type Redis from 'ioredis';
-import {Job, JobType} from '../contracts/Job';
-import {RedisStreamEntry, RedisStreamReadResult} from "../contracts/RedisStreamReadResult";
-import {StreamPendingEntries} from "../contracts/StreamPendingEntries";
+import type Redis from "ioredis";
+import { Job, JobType } from "../contracts/Job";
+import {
+	RedisStreamEntry,
+	RedisStreamReadResult,
+} from "../contracts/RedisStreamReadResult";
+import { StreamPendingEntries } from "../contracts/StreamPendingEntries";
 
 export interface JobConsumer {
-    init(): Promise<void>;
+	init(): Promise<void>;
 
-    read(blockMs: number, count?: number): Promise<Job[]>;
+	read(blockMs: number, count?: number): Promise<Job[]>;
 
-    ack(entryId: string[]): Promise<void>;
+	ack(entryId: string[]): Promise<void>;
+
+	del(messageIds: string[]): Promise<number>;
 }
 
 export type RedisJobConsumerConfig = {
-    jobStreamKey: string;
-    jobDedupePrefix: string;
-    groupName: string;
-    consumerName: string;
-    roomIdField: string;
-    typeField: string;
-    maxRetries: number;
+	jobStreamKey: string;
+	jobDedupePrefix: string;
+	groupName: string;
+	consumerName: string;
+	roomIdField: string;
+	typeField: string;
+	maxRetries: number;
 };
 
 export class RedisStreamJobConsumer implements JobConsumer {
-    constructor(
-        private readonly redis: Redis,
-        private readonly config: RedisJobConsumerConfig
-    ) {
-    }
+	constructor(
+		private readonly redis: Redis,
+		private readonly config: RedisJobConsumerConfig,
+	) {}
 
-    async init(): Promise<void> {
-        try {
-            await this.redis.xgroup(
-                'CREATE',
-                this.config.jobStreamKey,
-                this.config.groupName,
-                '$',
-                'MKSTREAM'
-            );
-        } catch (err: any) {
-            if (!err.message.includes('BUSYGROUP')) {
-                throw err;
-            }
-        }
-    }
+	async init(): Promise<void> {
+		try {
+			await this.redis.xgroup(
+				"CREATE",
+				this.config.jobStreamKey,
+				this.config.groupName,
+				"$",
+				"MKSTREAM",
+			);
+		} catch (err: any) {
+			if (!err.message.includes("BUSYGROUP")) {
+				throw err;
+			}
+		}
+	}
 
-    async read(blockMs: number, count: number = 1): Promise<Job[]> {
-        const pendingResults = await this.redis.xreadgroup(
-            'GROUP', this.config.groupName, this.config.consumerName,
-            'COUNT', count,
-            'STREAMS', this.config.jobStreamKey,
-            '0'
-        ) as RedisStreamReadResult | null;
+	async read(blockMs: number, count: number = 1): Promise<Job[]> {
+		const pendingResults = (await this.redis.xreadgroup(
+			"GROUP",
+			this.config.groupName,
+			this.config.consumerName,
+			"COUNT",
+			count,
+			"STREAMS",
+			this.config.jobStreamKey,
+			"0",
+		)) as RedisStreamReadResult | null;
 
-        if (pendingResults && pendingResults.length > 0 && pendingResults[0][1].length > 0) {
-            const pendingJobs = await this.processPending(count, pendingResults);
-            if (pendingJobs !== null) return pendingJobs;
-        }
+		if (
+			pendingResults &&
+			pendingResults.length > 0 &&
+			pendingResults[0][1].length > 0
+		) {
+			const pendingJobs = await this.processPending(count, pendingResults);
+			if (pendingJobs !== null) return pendingJobs;
+		}
 
-        const results = await this.redis.xreadgroup(
-            'GROUP',
-            this.config.groupName,
-            this.config.consumerName,
-            'COUNT',
-            count,
-            'BLOCK',
-            blockMs,
-            'STREAMS',
-            this.config.jobStreamKey,
-            '>'
-        ) as RedisStreamReadResult | null;
+		const results = (await this.redis.xreadgroup(
+			"GROUP",
+			this.config.groupName,
+			this.config.consumerName,
+			"COUNT",
+			count,
+			"BLOCK",
+			blockMs,
+			"STREAMS",
+			this.config.jobStreamKey,
+			">",
+		)) as RedisStreamReadResult | null;
 
-        if (!results || results.length < 1) return [];
+		if (!results || results.length < 1) return [];
 
-        const {jobs, badEntryIds} = this.parseEntries(results);
-        if (badEntryIds.length > 0) {
-            await this.ack(badEntryIds);
-        }
-        return jobs;
-    }
+		const { jobs, badEntryIds } = this.parseEntries(results);
+		if (badEntryIds.length > 0) {
+			await this.ack(badEntryIds);
+		}
+		return jobs;
+	}
 
-    async ack(entryId: string[]): Promise<void> {
-        if (entryId == null || entryId.length === 0) return;
+	async ack(entryId: string[]): Promise<void> {
+		if (entryId == null || entryId.length === 0) return;
 
-        await this.redis.xack(
-            this.config.jobStreamKey,
-            this.config.groupName,
-            ...entryId
-        );
-    }
+		await this.redis.xack(
+			this.config.jobStreamKey,
+			this.config.groupName,
+			...entryId,
+		);
+	}
 
-    private async processPending(count: number = 1, pendingResults: RedisStreamReadResult) {
-        const [, entries] = pendingResults[0];
-        const entryIds = entries.map(([id]) => id);
+	async del(messageIds: string[]): Promise<number> {
+		if (messageIds.length === 0) return 0;
+		return await this.redis.xdel(this.config.jobStreamKey, ...messageIds);
+	}
 
-        const pendingDetails = await this.redis.xpending(
-            this.config.jobStreamKey,
-            this.config.groupName,
-            'IDLE', 0,
-            entryIds[0],
-            entryIds[entryIds.length - 1],
-            count
-        ) as StreamPendingEntries;
+	private async processPending(
+		count: number = 1,
+		pendingResults: RedisStreamReadResult,
+	) {
+		const [, entries] = pendingResults[0];
+		const entryIds = entries.map(([id]) => id);
 
-        const validEntries: RedisStreamEntry[] = [];
-        const idsToAbandon: string[] = [];
+		const pendingDetails = (await this.redis.xpending(
+			this.config.jobStreamKey,
+			this.config.groupName,
+			"IDLE",
+			0,
+			entryIds[0],
+			entryIds[entryIds.length - 1],
+			count,
+		)) as StreamPendingEntries;
 
-        const deliveryById = new Map<string, number>();
-        for (const p of pendingDetails) {
-            deliveryById.set(p[0], Number(p[3]));
-        }
+		const validEntries: RedisStreamEntry[] = [];
+		const idsToAbandon: string[] = [];
 
-        entries.forEach((entry,) => {
-            const id = entry[0];
-            const deliveryCount = deliveryById.get(id);
-            if (deliveryCount == null) return;
-            if (deliveryCount > this.config.maxRetries) {
-                idsToAbandon.push(entry[0]);
-                console.warn(`[JobConsumer] 재시도 초과(${deliveryCount}), 포기: ${entry[0]}`);
-            } else {
-                validEntries.push(entry);
-            }
-        });
+		const deliveryById = new Map<string, number>();
+		for (const p of pendingDetails) {
+			deliveryById.set(p[0], Number(p[3]));
+		}
 
-        if (idsToAbandon.length > 0) {
-            await this.ack(idsToAbandon);
-        }
+		entries.forEach((entry) => {
+			const id = entry[0];
+			const deliveryCount = deliveryById.get(id);
+			if (deliveryCount == null) return;
+			if (deliveryCount > this.config.maxRetries) {
+				idsToAbandon.push(entry[0]);
+				console.warn(
+					`[JobConsumer] 재시도 초과(${deliveryCount}), 포기: ${entry[0]}`,
+				);
+			} else {
+				validEntries.push(entry);
+			}
+		});
 
-        if (validEntries.length > 0) {
-            const {jobs, badEntryIds} = this.parseEntries([[this.config.jobStreamKey, validEntries]]);
-            if (badEntryIds.length > 0) {
-                await this.ack(badEntryIds);
-            }
-            return jobs.length > 0 ? jobs : null;
-        }
-        return null;
-    }
+		if (idsToAbandon.length > 0) {
+			await this.ack(idsToAbandon);
+		}
 
-    private parseEntries(results: RedisStreamReadResult): {
-        jobs: Job[];
-        badEntryIds: string[];
-    } {
-        const [, entries] = results[0];
+		if (validEntries.length > 0) {
+			const { jobs, badEntryIds } = this.parseEntries([
+				[this.config.jobStreamKey, validEntries],
+			]);
+			if (badEntryIds.length > 0) {
+				await this.ack(badEntryIds);
+			}
+			return jobs.length > 0 ? jobs : null;
+		}
+		return null;
+	}
 
-        const badEntryIds: string[] = [];
-        const jobs: Job[] = [];
+	private parseEntries(results: RedisStreamReadResult): {
+		jobs: Job[];
+		badEntryIds: string[];
+	} {
+		const [, entries] = results[0];
 
-        for (const [entryId, rawData] of entries) {
-            try {
-                const data: Record<string, string> = {};
-                for (let i = 0; i < rawData.length; i += 2) {
-                    data[rawData[i]] = rawData[i + 1];
-                }
-                const rawType = data[this.config.typeField] as JobType;
-                if (rawType !== JobType.SNAPSHOT && rawType !== JobType.SYNC) {
-                    throw new Error(`Unknown job type: ${rawType}`);
-                }
-                const roomId = data[this.config.roomIdField];
-                if (!roomId) {
-                    throw new Error(`Missing roomId field`);
-                }
+		const badEntryIds: string[] = [];
+		const jobs: Job[] = [];
 
-                jobs.push({
-                    entryId: entryId,
-                    roomId: roomId,
-                    type: rawType
-                });
-            } catch (error) {
-                console.error(
-                    `[RedisJobConsumer] 파싱 실패 entryId=${entryId}`,
-                    error
-                );
-                badEntryIds.push(entryId);
-            }
-        }
+		for (const [entryId, rawData] of entries) {
+			try {
+				const data: Record<string, string> = {};
+				for (let i = 0; i < rawData.length; i += 2) {
+					data[rawData[i]] = rawData[i + 1];
+				}
+				const rawType = data[this.config.typeField] as JobType;
+				if (rawType !== JobType.SNAPSHOT && rawType !== JobType.SYNC) {
+					throw new Error(`Unknown job type: ${rawType}`);
+				}
+				const roomId = data[this.config.roomIdField];
+				if (!roomId) {
+					throw new Error(`Missing roomId field`);
+				}
 
-        return {jobs, badEntryIds};
-    }
+				jobs.push({
+					entryId: entryId,
+					roomId: roomId,
+					type: rawType,
+				});
+			} catch (error) {
+				console.error(`[RedisJobConsumer] 파싱 실패 entryId=${entryId}`, error);
+				badEntryIds.push(entryId);
+			}
+		}
+
+		return { jobs, badEntryIds };
+	}
 }
-

--- a/backend/yjs-runner/app/src/infrastructure/JobConsumer.ts
+++ b/backend/yjs-runner/app/src/infrastructure/JobConsumer.ts
@@ -1,201 +1,177 @@
 import type Redis from "ioredis";
 import { Job, JobType } from "../contracts/Job";
-import {
-	RedisStreamEntry,
-	RedisStreamReadResult,
-} from "../contracts/RedisStreamReadResult";
+import { RedisStreamEntry, RedisStreamReadResult } from "../contracts/RedisStreamReadResult";
 import { StreamPendingEntries } from "../contracts/StreamPendingEntries";
 
 export interface JobConsumer {
-	init(): Promise<void>;
+    init(): Promise<void>;
 
-	read(blockMs: number, count?: number): Promise<Job[]>;
+    read(blockMs: number, count?: number): Promise<Job[]>;
 
-	ack(entryId: string[]): Promise<void>;
+    ack(entryId: string[]): Promise<void>;
 
-	del(messageIds: string[]): Promise<number>;
+    del(messageIds: string[]): Promise<number>;
 }
 
 export type RedisJobConsumerConfig = {
-	jobStreamKey: string;
-	jobDedupePrefix: string;
-	groupName: string;
-	consumerName: string;
-	roomIdField: string;
-	typeField: string;
-	maxRetries: number;
+    jobStreamKey: string;
+    jobDedupePrefix: string;
+    groupName: string;
+    consumerName: string;
+    roomIdField: string;
+    typeField: string;
+    maxRetries: number;
 };
 
 export class RedisStreamJobConsumer implements JobConsumer {
-	constructor(
-		private readonly redis: Redis,
-		private readonly config: RedisJobConsumerConfig,
-	) {}
+    constructor(
+        private readonly redis: Redis,
+        private readonly config: RedisJobConsumerConfig,
+    ) {}
 
-	async init(): Promise<void> {
-		try {
-			await this.redis.xgroup(
-				"CREATE",
-				this.config.jobStreamKey,
-				this.config.groupName,
-				"$",
-				"MKSTREAM",
-			);
-		} catch (err: any) {
-			if (!err.message.includes("BUSYGROUP")) {
-				throw err;
-			}
-		}
-	}
+    async init(): Promise<void> {
+        try {
+            await this.redis.xgroup("CREATE", this.config.jobStreamKey, this.config.groupName, "$", "MKSTREAM");
+        } catch (err: any) {
+            if (!err.message.includes("BUSYGROUP")) {
+                throw err;
+            }
+        }
+    }
 
-	async read(blockMs: number, count: number = 1): Promise<Job[]> {
-		const pendingResults = (await this.redis.xreadgroup(
-			"GROUP",
-			this.config.groupName,
-			this.config.consumerName,
-			"COUNT",
-			count,
-			"STREAMS",
-			this.config.jobStreamKey,
-			"0",
-		)) as RedisStreamReadResult | null;
+    async read(blockMs: number, count: number = 1): Promise<Job[]> {
+        const pendingResults = (await this.redis.xreadgroup(
+            "GROUP",
+            this.config.groupName,
+            this.config.consumerName,
+            "COUNT",
+            count,
+            "STREAMS",
+            this.config.jobStreamKey,
+            "0",
+        )) as RedisStreamReadResult | null;
 
-		if (
-			pendingResults &&
-			pendingResults.length > 0 &&
-			pendingResults[0][1].length > 0
-		) {
-			const pendingJobs = await this.processPending(count, pendingResults);
-			if (pendingJobs !== null) return pendingJobs;
-		}
+        if (pendingResults && pendingResults.length > 0 && pendingResults[0][1].length > 0) {
+            const pendingJobs = await this.processPending(count, pendingResults);
+            if (pendingJobs !== null) return pendingJobs;
+        }
 
-		const results = (await this.redis.xreadgroup(
-			"GROUP",
-			this.config.groupName,
-			this.config.consumerName,
-			"COUNT",
-			count,
-			"BLOCK",
-			blockMs,
-			"STREAMS",
-			this.config.jobStreamKey,
-			">",
-		)) as RedisStreamReadResult | null;
+        const results = (await this.redis.xreadgroup(
+            "GROUP",
+            this.config.groupName,
+            this.config.consumerName,
+            "COUNT",
+            count,
+            "BLOCK",
+            blockMs,
+            "STREAMS",
+            this.config.jobStreamKey,
+            ">",
+        )) as RedisStreamReadResult | null;
 
-		if (!results || results.length < 1) return [];
+        if (!results || results.length < 1) return [];
 
-		const { jobs, badEntryIds } = this.parseEntries(results);
-		if (badEntryIds.length > 0) {
-			await this.ack(badEntryIds);
-		}
-		return jobs;
-	}
+        const { jobs, badEntryIds } = this.parseEntries(results);
+        if (badEntryIds.length > 0) {
+            await this.ack(badEntryIds);
+        }
+        return jobs;
+    }
 
-	async ack(entryId: string[]): Promise<void> {
-		if (entryId == null || entryId.length === 0) return;
+    async ack(entryId: string[]): Promise<void> {
+        if (entryId == null || entryId.length === 0) return;
 
-		await this.redis.xack(
-			this.config.jobStreamKey,
-			this.config.groupName,
-			...entryId,
-		);
-	}
+        await this.redis.xack(this.config.jobStreamKey, this.config.groupName, ...entryId);
+    }
 
-	async del(messageIds: string[]): Promise<number> {
-		if (messageIds.length === 0) return 0;
-		return await this.redis.xdel(this.config.jobStreamKey, ...messageIds);
-	}
+    async del(messageIds: string[]): Promise<number> {
+        if (messageIds.length === 0) return 0;
+        return await this.redis.xdel(this.config.jobStreamKey, ...messageIds);
+    }
 
-	private async processPending(
-		count: number = 1,
-		pendingResults: RedisStreamReadResult,
-	) {
-		const [, entries] = pendingResults[0];
-		const entryIds = entries.map(([id]) => id);
+    private async processPending(count: number = 1, pendingResults: RedisStreamReadResult) {
+        const [, entries] = pendingResults[0];
+        const entryIds = entries.map(([id]) => id);
 
-		const pendingDetails = (await this.redis.xpending(
-			this.config.jobStreamKey,
-			this.config.groupName,
-			"IDLE",
-			0,
-			entryIds[0],
-			entryIds[entryIds.length - 1],
-			count,
-		)) as StreamPendingEntries;
+        const pendingDetails = (await this.redis.xpending(
+            this.config.jobStreamKey,
+            this.config.groupName,
+            "IDLE",
+            0,
+            entryIds[0],
+            entryIds[entryIds.length - 1],
+            count,
+        )) as StreamPendingEntries;
 
-		const validEntries: RedisStreamEntry[] = [];
-		const idsToAbandon: string[] = [];
+        const validEntries: RedisStreamEntry[] = [];
+        const idsToAbandon: string[] = [];
 
-		const deliveryById = new Map<string, number>();
-		for (const p of pendingDetails) {
-			deliveryById.set(p[0], Number(p[3]));
-		}
+        const deliveryById = new Map<string, number>();
+        for (const p of pendingDetails) {
+            deliveryById.set(p[0], Number(p[3]));
+        }
 
-		entries.forEach((entry) => {
-			const id = entry[0];
-			const deliveryCount = deliveryById.get(id);
-			if (deliveryCount == null) return;
-			if (deliveryCount > this.config.maxRetries) {
-				idsToAbandon.push(entry[0]);
-				console.warn(
-					`[JobConsumer] 재시도 초과(${deliveryCount}), 포기: ${entry[0]}`,
-				);
-			} else {
-				validEntries.push(entry);
-			}
-		});
+        entries.forEach((entry) => {
+            const id = entry[0];
+            const deliveryCount = deliveryById.get(id);
+            if (deliveryCount == null) return;
+            if (deliveryCount > this.config.maxRetries) {
+                idsToAbandon.push(entry[0]);
+                console.warn(`[JobConsumer] 재시도 초과(${deliveryCount}), 포기: ${entry[0]}`);
+            } else {
+                validEntries.push(entry);
+            }
+        });
 
-		if (idsToAbandon.length > 0) {
-			await this.ack(idsToAbandon);
-		}
+        if (idsToAbandon.length > 0) {
+            await this.ack(idsToAbandon);
+        }
 
-		if (validEntries.length > 0) {
-			const { jobs, badEntryIds } = this.parseEntries([
-				[this.config.jobStreamKey, validEntries],
-			]);
-			if (badEntryIds.length > 0) {
-				await this.ack(badEntryIds);
-			}
-			return jobs.length > 0 ? jobs : null;
-		}
-		return null;
-	}
+        if (validEntries.length > 0) {
+            const { jobs, badEntryIds } = this.parseEntries([[this.config.jobStreamKey, validEntries]]);
+            if (badEntryIds.length > 0) {
+                await this.ack(badEntryIds);
+            }
+            return jobs.length > 0 ? jobs : null;
+        }
+        return null;
+    }
 
-	private parseEntries(results: RedisStreamReadResult): {
-		jobs: Job[];
-		badEntryIds: string[];
-	} {
-		const [, entries] = results[0];
+    private parseEntries(results: RedisStreamReadResult): {
+        jobs: Job[];
+        badEntryIds: string[];
+    } {
+        const [, entries] = results[0];
 
-		const badEntryIds: string[] = [];
-		const jobs: Job[] = [];
+        const badEntryIds: string[] = [];
+        const jobs: Job[] = [];
 
-		for (const [entryId, rawData] of entries) {
-			try {
-				const data: Record<string, string> = {};
-				for (let i = 0; i < rawData.length; i += 2) {
-					data[rawData[i]] = rawData[i + 1];
-				}
-				const rawType = data[this.config.typeField] as JobType;
-				if (rawType !== JobType.SNAPSHOT && rawType !== JobType.SYNC) {
-					throw new Error(`Unknown job type: ${rawType}`);
-				}
-				const roomId = data[this.config.roomIdField];
-				if (!roomId) {
-					throw new Error(`Missing roomId field`);
-				}
+        for (const [entryId, rawData] of entries) {
+            try {
+                const data: Record<string, string> = {};
+                for (let i = 0; i < rawData.length; i += 2) {
+                    data[rawData[i]] = rawData[i + 1];
+                }
+                const rawType = data[this.config.typeField] as JobType;
+                if (rawType !== JobType.SNAPSHOT && rawType !== JobType.SYNC) {
+                    throw new Error(`Unknown job type: ${rawType}`);
+                }
+                const roomId = data[this.config.roomIdField];
+                if (!roomId) {
+                    throw new Error(`Missing roomId field`);
+                }
 
-				jobs.push({
-					entryId: entryId,
-					roomId: roomId,
-					type: rawType,
-				});
-			} catch (error) {
-				console.error(`[RedisJobConsumer] 파싱 실패 entryId=${entryId}`, error);
-				badEntryIds.push(entryId);
-			}
-		}
+                jobs.push({
+                    entryId: entryId,
+                    roomId: roomId,
+                    type: rawType,
+                });
+            } catch (error) {
+                console.error(`[RedisJobConsumer] 파싱 실패 entryId=${entryId}`, error);
+                badEntryIds.push(entryId);
+            }
+        }
 
-		return { jobs, badEntryIds };
-	}
+        return { jobs, badEntryIds };
+    }
 }

--- a/backend/yjs-runner/app/src/infrastructure/MindmapTicketIssuer.ts
+++ b/backend/yjs-runner/app/src/infrastructure/MindmapTicketIssuer.ts
@@ -10,17 +10,16 @@ type JwtClaims = {
 
 export class MindmapTicketIssuer {
 	private readonly secret: string;
-	private readonly issuer: string;
 	private readonly ttlSeconds: number;
+	private readonly issuer = "episode";
 
-	constructor(opts: { secret: string; issuer?: string; ttlSeconds?: number }) {
-		if (!opts.secret) {
+	constructor(secret: string, ttlSeconds?: number) {
+		if (!secret) {
 			throw new Error(`JWT secret is missing.`);
 		}
 
-		this.secret = opts.secret;
-		this.issuer = opts.issuer ?? "episode";
-		this.ttlSeconds = opts.ttlSeconds ?? 30;
+		this.secret = secret;
+		this.ttlSeconds = ttlSeconds ?? 30;
 	}
 
 	issue(mindmapId: string): string {

--- a/backend/yjs-runner/app/src/infrastructure/MindmapTicketIssuer.ts
+++ b/backend/yjs-runner/app/src/infrastructure/MindmapTicketIssuer.ts
@@ -1,0 +1,48 @@
+import jwt from "jsonwebtoken";
+import { randomUUID } from "crypto";
+
+type JwtClaims = {
+	typ: "ws-mindmap";
+	mindmapId: string;
+	iat: number;
+	exp: number;
+};
+
+export class MindmapTicketIssuer {
+	private readonly secret: string;
+	private readonly issuer: string;
+	private readonly ttlSeconds: number;
+
+	constructor(opts: { secret: string; issuer?: string; ttlSeconds?: number }) {
+		if (!opts.secret) {
+			throw new Error(`JWT secret is missing.`);
+		}
+
+		this.secret = opts.secret;
+		this.issuer = opts.issuer ?? "episode";
+		this.ttlSeconds = opts.ttlSeconds ?? 30;
+	}
+
+	issue(mindmapId: string): string {
+		if (!mindmapId || mindmapId.trim().length === 0) {
+			throw new Error("mindmapId is required");
+		}
+
+		const now = Math.floor(Date.now() / 1000);
+
+		const payload: JwtClaims = {
+			typ: "ws-mindmap",
+			mindmapId,
+			iat: now,
+			exp: now + this.ttlSeconds,
+		};
+
+		return jwt.sign(payload, this.secret, {
+			algorithm: "HS256",
+			issuer: this.issuer,
+			subject: "0",
+			jwtid: randomUUID(),
+			noTimestamp: true,
+		});
+	}
+}

--- a/backend/yjs-runner/app/src/infrastructure/MindmapTicketIssuer.ts
+++ b/backend/yjs-runner/app/src/infrastructure/MindmapTicketIssuer.ts
@@ -2,46 +2,46 @@ import jwt from "jsonwebtoken";
 import { randomUUID } from "crypto";
 
 type JwtClaims = {
-	typ: "ws-mindmap";
-	mindmapId: string;
-	iat: number;
-	exp: number;
+    typ: "ws-mindmap";
+    mindmapId: string;
+    iat: number;
+    exp: number;
 };
 
 export class MindmapTicketIssuer {
-	private readonly secret: string;
-	private readonly ttlSeconds: number;
-	private readonly issuer = "episode";
+    private readonly secret: string;
+    private readonly ttlSeconds: number;
+    private readonly issuer = "episode";
 
-	constructor(secret: string, ttlSeconds?: number) {
-		if (!secret) {
-			throw new Error(`JWT secret is missing.`);
-		}
+    constructor(secret: string, ttlSeconds?: number) {
+        if (!secret) {
+            throw new Error(`JWT secret is missing.`);
+        }
 
-		this.secret = secret;
-		this.ttlSeconds = ttlSeconds ?? 30;
-	}
+        this.secret = secret;
+        this.ttlSeconds = ttlSeconds ?? 30;
+    }
 
-	issue(mindmapId: string): string {
-		if (!mindmapId || mindmapId.trim().length === 0) {
-			throw new Error("mindmapId is required");
-		}
+    issue(mindmapId: string): string {
+        if (!mindmapId || mindmapId.trim().length === 0) {
+            throw new Error("mindmapId is required");
+        }
 
-		const now = Math.floor(Date.now() / 1000);
+        const now = Math.floor(Date.now() / 1000);
 
-		const payload: JwtClaims = {
-			typ: "ws-mindmap",
-			mindmapId,
-			iat: now,
-			exp: now + this.ttlSeconds,
-		};
+        const payload: JwtClaims = {
+            typ: "ws-mindmap",
+            mindmapId,
+            iat: now,
+            exp: now + this.ttlSeconds,
+        };
 
-		return jwt.sign(payload, this.secret, {
-			algorithm: "HS256",
-			issuer: this.issuer,
-			subject: "0",
-			jwtid: randomUUID(),
-			noTimestamp: true,
-		});
-	}
+        return jwt.sign(payload, this.secret, {
+            algorithm: "HS256",
+            issuer: this.issuer,
+            subject: "0",
+            jwtid: randomUUID(),
+            noTimestamp: true,
+        });
+    }
 }

--- a/backend/yjs-runner/app/src/infrastructure/S3SnapshotStorage.ts
+++ b/backend/yjs-runner/app/src/infrastructure/S3SnapshotStorage.ts
@@ -1,4 +1,4 @@
-import {GetObjectCommand, NoSuchKey, PutObjectCommand, S3Client} from "@aws-sdk/client-s3";
+import { GetObjectCommand, NoSuchKey, PutObjectCommand, S3Client } from "@aws-sdk/client-s3";
 
 export interface SnapshotStorage {
     upload(roomId: string, data: Uint8Array): Promise<void>;
@@ -24,12 +24,13 @@ export class S3SnapshotStorage implements SnapshotStorage {
             region: config.region,
             endpoint: config.endpoint,
             forcePathStyle: config.forcePathStyle ?? !!config.endpoint,
-            credentials: (config.accessKey && config.secretKey)
-                ? {
-                    accessKeyId: config.accessKey,
-                    secretAccessKey: config.secretKey,
-                }
-                : undefined,
+            credentials:
+                config.accessKey && config.secretKey
+                    ? {
+                          accessKeyId: config.accessKey,
+                          secretAccessKey: config.secretKey,
+                      }
+                    : undefined,
         });
     }
 
@@ -42,7 +43,7 @@ export class S3SnapshotStorage implements SnapshotStorage {
             Bucket: this.config.bucket,
             Key: this.getFullKey(roomId),
             Body: data,
-            ContentType: 'application/octet-stream',
+            ContentType: "application/octet-stream",
         });
 
         await this.client.send(command);
@@ -61,7 +62,6 @@ export class S3SnapshotStorage implements SnapshotStorage {
             }
 
             return await response.Body.transformToByteArray();
-
         } catch (error) {
             if (error instanceof NoSuchKey) {
                 console.info(`[S3Storage] 해당 roomId에 대한 데이터가 존재하지 않습니다.: ${roomId}.`);

--- a/backend/yjs-runner/app/src/infrastructure/UpdateRepository.ts
+++ b/backend/yjs-runner/app/src/infrastructure/UpdateRepository.ts
@@ -1,6 +1,6 @@
-import type Redis from 'ioredis';
-import * as decoding from 'lib0/decoding';
-import {SnapshotBuildContext} from "../contracts/SnapshotBuildContext";
+import type Redis from "ioredis";
+import * as decoding from "lib0/decoding";
+import { SnapshotBuildContext } from "../contracts/SnapshotBuildContext";
 
 export interface UpdateRepository {
     fetchAllUpdates(roomId: string): Promise<SnapshotBuildContext>;
@@ -13,14 +13,13 @@ export type UpdateRepositoryConfig = {
 };
 
 export class RedisUpdateRepository implements UpdateRepository {
-    private readonly defaultLastEntryId = "0-0"
+    private readonly defaultLastEntryId = "0-0";
     private static readonly FIELD_U = 0x75; // 'u'
 
     constructor(
         private readonly redis: Redis,
-        private readonly config: UpdateRepositoryConfig
-    ) {
-    }
+        private readonly config: UpdateRepositoryConfig,
+    ) {}
 
     private getStreamKey(roomId: string): string {
         return `${this.config.updateStreamKeyPrefix}${roomId}`;
@@ -28,13 +27,13 @@ export class RedisUpdateRepository implements UpdateRepository {
 
     async fetchAllUpdates(roomId: string): Promise<SnapshotBuildContext> {
         const key = this.getStreamKey(roomId);
-        const entries = await this.redis.xrangeBuffer(key, '-', '+') as unknown as [Buffer, Buffer[]][];
+        const entries = (await this.redis.xrangeBuffer(key, "-", "+")) as unknown as [Buffer, Buffer[]][];
 
         if (!entries || entries.length === 0) {
             return {
                 lastEntryId: this.defaultLastEntryId,
                 roomId,
-                updateFrameList: []
+                updateFrameList: [],
             };
         }
 
@@ -54,14 +53,14 @@ export class RedisUpdateRepository implements UpdateRepository {
         return {
             lastEntryId,
             roomId,
-            updateFrameList
+            updateFrameList,
         };
     }
 
     async trim(roomId: string, lastEntryId: string): Promise<void> {
         if (lastEntryId === this.defaultLastEntryId) return;
         const key = this.getStreamKey(roomId);
-        await this.redis.xtrim(key, 'MINID', lastEntryId);
+        await this.redis.xtrim(key, "MINID", lastEntryId);
         await this.redis.xdel(key, lastEntryId);
     }
 
@@ -84,5 +83,4 @@ export class RedisUpdateRepository implements UpdateRepository {
             return null;
         }
     }
-
 }

--- a/backend/yjs-runner/app/src/infrastructure/WebsocketSyncClient.ts
+++ b/backend/yjs-runner/app/src/infrastructure/WebsocketSyncClient.ts
@@ -8,132 +8,128 @@ import { MindmapTicketIssuer } from "./MindmapTicketIssuer";
 const messageSync = 0;
 
 export class WebsocketSyncClient {
-	private readonly baseUrl: string;
-	private readonly timeoutMs: number;
-	private readonly ticketIssuer: MindmapTicketIssuer;
+    private readonly baseUrl: string;
+    private readonly timeoutMs: number;
+    private readonly ticketIssuer: MindmapTicketIssuer;
 
-	constructor(
-		ticketIssuer: MindmapTicketIssuer,
-		baseUrl: string,
-		timeoutMs?: number,
-	) {
-		this.baseUrl = baseUrl;
-		this.timeoutMs = timeoutMs ?? 10_000;
-		this.ticketIssuer = ticketIssuer;
-	}
+    constructor(ticketIssuer: MindmapTicketIssuer, baseUrl: string, timeoutMs?: number) {
+        this.baseUrl = baseUrl;
+        this.timeoutMs = timeoutMs ?? 10_000;
+        this.ticketIssuer = ticketIssuer;
+    }
 
-	async sync(doc: Y.Doc, roomId: string): Promise<Y.Doc> {
-		const token = this.ticketIssuer.issue(roomId);
+    async sync(doc: Y.Doc, roomId: string): Promise<Y.Doc> {
+        const token = this.ticketIssuer.issue(roomId);
 
-		const url = this.buildWsUrl(roomId, token);
-		return this.syncOnce(doc, url);
-	}
+        const url = this.buildWsUrl(roomId, token);
+        return this.syncOnce(doc, url);
+    }
 
-	private toUint8(msg: WebSocket.RawData): Uint8Array {
-		if (Buffer.isBuffer(msg)) {
-			return new Uint8Array(msg.buffer, msg.byteOffset, msg.byteLength);
-		}
-		if (msg instanceof ArrayBuffer) {
-			return new Uint8Array(msg);
-		}
-		if (Array.isArray(msg)) {
-			const b = Buffer.concat(msg);
-			return new Uint8Array(b.buffer, b.byteOffset, b.byteLength);
-		}
-		throw new TypeError(`Unexpected ws message ${typeof msg}`);
-	}
+    private toUint8(msg: WebSocket.RawData): Uint8Array {
+        if (Buffer.isBuffer(msg)) {
+            return new Uint8Array(msg.buffer, msg.byteOffset, msg.byteLength);
+        }
+        if (msg instanceof ArrayBuffer) {
+            return new Uint8Array(msg);
+        }
+        if (Array.isArray(msg)) {
+            const b = Buffer.concat(msg);
+            return new Uint8Array(b.buffer, b.byteOffset, b.byteLength);
+        }
+        throw new TypeError(`Unexpected ws message ${typeof msg}`);
+    }
 
-	private buildWsUrl(roomId: string, token?: string) {
-		const qs = token ? `?token=${encodeURIComponent(token)}` : "";
-		return `${this.baseUrl}/${encodeURIComponent(roomId)}${qs}`;
-	}
+    private buildWsUrl(roomId: string, token?: string) {
+        const qs = token ? `?token=${encodeURIComponent(token)}` : "";
+        return `${this.baseUrl}/${encodeURIComponent(roomId)}${qs}`;
+    }
 
-	private syncOnce(doc: Y.Doc, url: string): Promise<Y.Doc> {
-		return new Promise<Y.Doc>((resolve, reject) => {
-			let settled = false;
-			const ws = new WebSocket(url);
-			const timer = setTimeout(() => {
-				if (settled) return;
-				settled = true;
-				cleanup();
-				try {
-					ws.close();
-				} catch {}
-				reject(new Error(`Sync timeout`));
-			}, this.timeoutMs);
+    private syncOnce(doc: Y.Doc, url: string): Promise<Y.Doc> {
+        return new Promise<Y.Doc>((resolve, reject) => {
+            let settled = false;
+            const ws = new WebSocket(url);
+            const timer = setTimeout(() => {
+                if (settled) return;
+                settled = true;
+                cleanup();
+                try {
+                    ws.close();
+                } catch {}
+                reject(new Error(`Sync timeout`));
+            }, this.timeoutMs);
 
-			const cleanup = () => {
-				clearTimeout(timer);
-				ws.removeAllListeners();
-				try {
-					ws.close();
-				} catch {}
-			};
+            const cleanup = () => {
+                clearTimeout(timer);
+                ws.removeAllListeners();
+                try {
+                    ws.close();
+                } catch {}
+            };
 
-			ws.on("open", () => {
-				const enc = encoding.createEncoder();
-				encoding.writeVarUint(enc, messageSync);
-				syncProtocol.writeSyncStep1(enc, doc);
-				ws.send(encoding.toUint8Array(enc));
-			});
+            ws.on("open", () => {
+                const enc = encoding.createEncoder();
+                encoding.writeVarUint(enc, messageSync);
+                syncProtocol.writeSyncStep1(enc, doc);
+                ws.send(encoding.toUint8Array(enc));
+            });
 
-			ws.on("message", (msg: WebSocket.RawData) => {
-				try {
-					const buf = this.toUint8(msg);
+            ws.on("message", (msg: WebSocket.RawData) => {
+                try {
+                    const buf = this.toUint8(msg);
 
-					const dec = decoding.createDecoder(buf);
+                    const dec = decoding.createDecoder(buf);
 
-					const outerType = decoding.readVarUint(dec);
-					if (outerType !== messageSync) return;
+                    const outerType = decoding.readVarUint(dec);
+                    if (outerType !== messageSync) return;
 
-					const innerType = decoding.readVarUint(dec);
+                    const innerType = decoding.readVarUint(dec);
 
-					if (innerType === syncProtocol.messageYjsUpdate) return;
+                    if (innerType === syncProtocol.messageYjsUpdate) return;
 
-					if (innerType === syncProtocol.messageYjsSyncStep1) {
-						const replyEnc = encoding.createEncoder();
-						encoding.writeVarUint(replyEnc, messageSync);
+                    if (innerType === syncProtocol.messageYjsSyncStep1) {
+                        const replyEnc = encoding.createEncoder();
+                        encoding.writeVarUint(replyEnc, messageSync);
 
-						syncProtocol.readSyncStep1(dec, replyEnc, doc);
+                        syncProtocol.readSyncStep1(dec, replyEnc, doc);
 
-						if (encoding.length(replyEnc) > 1) {
-							ws.send(encoding.toUint8Array(replyEnc));
-						}
-						return;
-					}
+                        if (encoding.length(replyEnc) > 1) {
+                            ws.send(encoding.toUint8Array(replyEnc));
+                        }
+                        return;
+                    }
 
-					if (innerType === syncProtocol.messageYjsSyncStep2) {
-						syncProtocol.readSyncStep2(dec, doc, null);
+                    if (innerType === syncProtocol.messageYjsSyncStep2) {
+                        syncProtocol.readSyncStep2(dec, doc, null);
 
-						if (!settled) {
-							settled = true;
-							cleanup();
-							resolve(doc);
-						}
-						return;
-					}
-				} catch (e) {
-					if (!settled) {
-						settled = true;
-						cleanup();
-						reject(e instanceof Error ? e : new Error(String(e)));
-					}
-				}
-			});
+                        if (!settled) {
+                            settled = true;
+                            cleanup();
+                            resolve(doc);
+                        }
+                        return;
+                    }
+                } catch (e) {
+                    if (!settled) {
+                        settled = true;
+                        cleanup();
+                        reject(e instanceof Error ? e : new Error(String(e)));
+                    }
+                }
+            });
 
-			ws.on("error", (err) => {
-				if (settled) return;
-				settled = true;
-				cleanup();
-				reject(err);
-			});
+            ws.on("error", (err) => {
+                if (settled) return;
+                settled = true;
+                cleanup();
+                reject(err);
+            });
 
-			ws.on("close", () => {
-				if (settled) return;
-				settled = true;
-				cleanup();
-				reject(new Error(`Websocket closed before sync complete.`));
-			});
-		});
-	}
+            ws.on("close", () => {
+                if (settled) return;
+                settled = true;
+                cleanup();
+                reject(new Error(`Websocket closed before sync complete.`));
+            });
+        });
+    }
 }

--- a/backend/yjs-runner/app/src/infrastructure/WebsocketSyncClient.ts
+++ b/backend/yjs-runner/app/src/infrastructure/WebsocketSyncClient.ts
@@ -1,0 +1,128 @@
+import WebSocket from "ws";
+import * as Y from "yjs";
+import * as syncProtocol from "y-protocols/sync";
+import * as encoding from "lib0/encoding";
+import * as decoding from "lib0/decoding";
+import { MindmapTicketIssuer } from "./MindmapTicketIssuer";
+
+const messageSync = 0;
+
+export class WebsocketSyncClient {
+	private readonly baseUrl: string;
+	private readonly timeoutMs: number;
+	private readonly ticketIssuer: MindmapTicketIssuer;
+
+	constructor(
+		ticketIssuer: MindmapTicketIssuer,
+		baseUrl: string,
+		timeoutMs?: number,
+	) {
+		this.baseUrl = baseUrl;
+		this.timeoutMs = timeoutMs ?? 10_000;
+		this.ticketIssuer = ticketIssuer;
+	}
+
+	async sync(doc: Y.Doc, roomId: string): Promise<Y.Doc> {
+		const token = this.ticketIssuer.issue(roomId);
+
+		const url = this.buildWsUrl(roomId, token);
+		return this.syncOnce(doc, url);
+	}
+
+	private buildWsUrl(roomId: string, token?: string) {
+		const qs = token ? `?token=${encodeURIComponent(token)}` : "";
+		return `${this.baseUrl}/${encodeURIComponent(roomId)}${qs}`;
+	}
+
+	private syncOnce(doc: Y.Doc, url: string): Promise<Y.Doc> {
+		return new Promise<Y.Doc>((resolve, reject) => {
+			let settled = false;
+			const ws = new WebSocket(url);
+			const timer = setTimeout(() => {
+				if (settled) return;
+				settled = true;
+				cleanup();
+				try {
+					ws.close();
+				} catch {}
+				reject(new Error(`Sync timeout`));
+			}, this.timeoutMs);
+
+			const cleanup = () => {
+				clearTimeout(timer);
+				ws.removeAllListeners();
+				try {
+					ws.close();
+				} catch {}
+			};
+
+			ws.on("open", () => {
+				const enc = encoding.createEncoder();
+				encoding.writeVarUint(enc, messageSync);
+				syncProtocol.writeSyncStep1(enc, doc);
+				ws.send(encoding.toUint8Array(enc));
+			});
+
+			ws.on("message", (msg: WebSocket.RawData) => {
+				try {
+					const buf =
+						msg instanceof Buffer
+							? new Uint8Array(msg)
+							: new Uint8Array(msg as ArrayBuffer);
+
+					const dec = decoding.createDecoder(buf);
+
+					const outerType = decoding.readVarUint(dec);
+					if (outerType !== messageSync) return;
+
+					const innerType = decoding.readVarUint(dec);
+
+					if (innerType === syncProtocol.messageYjsUpdate) return;
+
+					if (innerType === syncProtocol.messageYjsSyncStep1) {
+						const replyEnc = encoding.createEncoder();
+						encoding.writeVarUint(replyEnc, messageSync);
+
+						syncProtocol.readSyncStep1(dec, replyEnc, doc);
+
+						if (encoding.length(replyEnc) > 1) {
+							ws.send(encoding.toUint8Array(replyEnc));
+						}
+						return;
+					}
+
+					if (innerType === syncProtocol.messageYjsSyncStep2) {
+						syncProtocol.readSyncStep2(dec, doc, null);
+
+						if (!settled) {
+							settled = true;
+							cleanup();
+							resolve(doc);
+						}
+						return;
+					}
+				} catch (e) {
+					if (!settled) {
+						settled = true;
+						cleanup();
+						reject(e instanceof Error ? e : new Error(String(e)));
+					}
+				}
+			});
+
+			ws.on("error", (err) => {
+				if (settled) return;
+				settled = true;
+				cleanup();
+				reject(err);
+			});
+
+			ws.on("close", () => {
+				if (settled) return;
+				settled = true;
+				cleanup();
+				reject(new Error(`Websocket closed before sync complete.`));
+			});
+		});
+	}
+}

--- a/backend/yjs-runner/app/src/server.ts
+++ b/backend/yjs-runner/app/src/server.ts
@@ -10,23 +10,23 @@ import { MindmapTicketIssuer } from "./infrastructure/MindmapTicketIssuer";
 import { WebsocketSyncClient } from "./infrastructure/WebsocketSyncClient";
 
 const redis = new Redis({
-	host: process.env.REDIS_HOST!,
-	port: Number(process.env.REDIS_PORT ?? 6379),
-	password: process.env.REDIS_PASSWORD,
+    host: process.env.REDIS_HOST!,
+    port: Number(process.env.REDIS_PORT ?? 6379),
+    password: process.env.REDIS_PASSWORD,
 });
 
 const updateRepo = new RedisUpdateRepository(redis, {
-	updateStreamKeyPrefix: process.env.UPDATE_STREAM_PREFIX!,
+    updateStreamKeyPrefix: process.env.UPDATE_STREAM_PREFIX!,
 });
 
 const storage = new S3SnapshotStorage({
-	region: process.env.AWS_REGION!,
-	bucket: process.env.S3_BUCKET!,
-	keyPrefix: process.env.S3_PREFIX!,
-	endpoint: process.env.S3_ENDPOINT,
-	accessKey: process.env.S3_ACCESS_KEY,
-	secretKey: process.env.S3_SECRET_KEY,
-	forcePathStyle: process.env.S3_FORCE_PATH_STYLE === "true",
+    region: process.env.AWS_REGION!,
+    bucket: process.env.S3_BUCKET!,
+    keyPrefix: process.env.S3_PREFIX!,
+    endpoint: process.env.S3_ENDPOINT,
+    accessKey: process.env.S3_ACCESS_KEY,
+    secretKey: process.env.S3_SECRET_KEY,
+    forcePathStyle: process.env.S3_FORCE_PATH_STYLE === "true",
 });
 
 const yjs = new DefaultYjsProcessor();
@@ -34,54 +34,51 @@ const yjs = new DefaultYjsProcessor();
 const ttl = Number(process.env.TOKEN_TTL_SEC);
 
 const ticketIssuer = new MindmapTicketIssuer(
-	process.env.JWT_MINDMAP_SECRET!,
-	Number.isFinite(ttl) && ttl > 0 ? ttl : undefined,
+    process.env.JWT_MINDMAP_SECRET!,
+    Number.isFinite(ttl) && ttl > 0 ? ttl : undefined,
 );
 
-const syncClient = new WebsocketSyncClient(
-	ticketIssuer,
-	process.env.WS_BASE_URL!,
-);
+const syncClient = new WebsocketSyncClient(ticketIssuer, process.env.WS_BASE_URL!);
 
 const service = new SnapshotService({
-	updateRepo,
-	yjs,
-	storage,
-	syncClient,
+    updateRepo,
+    yjs,
+    storage,
+    syncClient,
 });
 
 const consumer = new RedisStreamJobConsumer(redis, {
-	jobStreamKey: process.env.JOB_STREAM_KEY!,
-	jobDedupePrefix: process.env.JOB_DEDUPE_KEY_PRIFIX!,
-	groupName: process.env.JOB_GROUP_NAME!,
-	consumerName: process.env.JOB_CONSUMER_NAME!,
-	roomIdField: process.env.JOB_ROOM_FIELD ? process.env.JOB_ROOM_FIELD : "rid",
-	typeField: process.env.JOB_TYPE_FIELD ? process.env.JOB_TYPE_FIELD : "type",
-	maxRetries: Number(process.env.JOB_MAX_TRY ?? 5),
+    jobStreamKey: process.env.JOB_STREAM_KEY!,
+    jobDedupePrefix: process.env.JOB_DEDUPE_KEY_PRIFIX!,
+    groupName: process.env.JOB_GROUP_NAME!,
+    consumerName: process.env.JOB_CONSUMER_NAME!,
+    roomIdField: process.env.JOB_ROOM_FIELD ? process.env.JOB_ROOM_FIELD : "rid",
+    typeField: process.env.JOB_TYPE_FIELD ? process.env.JOB_TYPE_FIELD : "type",
+    maxRetries: Number(process.env.JOB_MAX_TRY ?? 5),
 });
 
 const worker = new SnapshotWorker({
-	consumer,
-	service,
-	blockMs: Number(process.env.JOB_BLOCK_MS ?? 10000),
-	count: Number(process.env.JOB_COUNT ?? 1),
+    consumer,
+    service,
+    blockMs: Number(process.env.JOB_BLOCK_MS ?? 10000),
+    count: Number(process.env.JOB_COUNT ?? 1),
 });
 
 async function main() {
-	await worker.init();
-	await worker.start();
+    await worker.init();
+    await worker.start();
 }
 
 main();
 
 process.on("SIGINT", async () => {
-	worker.stop();
-	await redis.quit();
-	process.exit(0);
+    worker.stop();
+    await redis.quit();
+    process.exit(0);
 });
 
 process.on("SIGTERM", async () => {
-	worker.stop();
-	await redis.quit();
-	process.exit(0);
+    worker.stop();
+    await redis.quit();
+    process.exit(0);
 });

--- a/backend/yjs-runner/app/src/server.ts
+++ b/backend/yjs-runner/app/src/server.ts
@@ -1,67 +1,72 @@
-import 'dotenv/config';
-import Redis from 'ioredis';
-import {S3SnapshotStorage} from './infrastructure/S3SnapshotStorage';
-import {RedisUpdateRepository} from './infrastructure/UpdateRepository';
-import {DefaultYjsProcessor} from './domain/YjsProcessor';
-import {SnapshotService} from './services/SnapshotService';
-import {RedisStreamJobConsumer} from './infrastructure/JobConsumer';
-import {SnapshotWorker} from './worker/SnapshotWorker';
+import "dotenv/config";
+import Redis from "ioredis";
+import { S3SnapshotStorage } from "./infrastructure/S3SnapshotStorage";
+import { RedisUpdateRepository } from "./infrastructure/UpdateRepository";
+import { DefaultYjsProcessor } from "./domain/YjsProcessor";
+import { SnapshotService } from "./services/SnapshotService";
+import { RedisStreamJobConsumer } from "./infrastructure/JobConsumer";
+import { SnapshotWorker } from "./worker/SnapshotWorker";
+import { MindmapTicketIssuer } from "./infrastructure/MindmapTicketIssuer";
 
 const redis = new Redis({
-    host: process.env.REDIS_HOST!,
-    port: Number(process.env.REDIS_PORT ?? 6379),
+	host: process.env.REDIS_HOST!,
+	port: Number(process.env.REDIS_PORT ?? 6379),
 });
 
 const updateRepo = new RedisUpdateRepository(redis, {
-    updateStreamKeyPrefix: process.env.UPDATE_STREAM_PREFIX!,
+	updateStreamKeyPrefix: process.env.UPDATE_STREAM_PREFIX!,
 });
 
 const storage = new S3SnapshotStorage({
-    region: process.env.AWS_REGION!,
-    bucket: process.env.S3_BUCKET!,
-    keyPrefix: process.env.S3_PREFIX!,
-    endpoint: process.env.S3_ENDPOINT,
-    accessKey: process.env.S3_ACCESS_KEY,
-    secretKey: process.env.S3_SECRET_KEY,
-    forcePathStyle: process.env.S3_FORCE_PATH_STYLE === 'true',
+	region: process.env.AWS_REGION!,
+	bucket: process.env.S3_BUCKET!,
+	keyPrefix: process.env.S3_PREFIX!,
+	endpoint: process.env.S3_ENDPOINT,
+	accessKey: process.env.S3_ACCESS_KEY,
+	secretKey: process.env.S3_SECRET_KEY,
+	forcePathStyle: process.env.S3_FORCE_PATH_STYLE === "true",
 });
 
 const yjs = new DefaultYjsProcessor();
 
-const service = new SnapshotService({updateRepo, yjs, storage});
+const ticketIssuer = new MindmapTicketIssuer({
+	secret: process.env.JWT_MINDMAP_SECRET!,
+});
+
+const service = new SnapshotService({ updateRepo, yjs, storage });
 
 const consumer = new RedisStreamJobConsumer(redis, {
-    jobStreamKey: process.env.JOB_STREAM_KEY!,
-    jobDedupePrefix: process.env.JOB_DEDUPE_KEY_PRIFIX!,
-    groupName: process.env.JOB_GROUP_NAME!,
-    consumerName: process.env.JOB_CONSUMER_NAME!,
-    roomIdField: process.env.JOB_ROOM_FIELD ? process.env.JOB_ROOM_FIELD : "rid",
-    typeField: process.env.JOB_TYPE_FIELD ? process.env.JOB_TYPE_FIELD : "type",
-    maxRetries: Number(process.env.JOB_MAX_TRY ?? 5),
+	jobStreamKey: process.env.JOB_STREAM_KEY!,
+	jobDedupePrefix: process.env.JOB_DEDUPE_KEY_PRIFIX!,
+	groupName: process.env.JOB_GROUP_NAME!,
+	consumerName: process.env.JOB_CONSUMER_NAME!,
+	roomIdField: process.env.JOB_ROOM_FIELD ? process.env.JOB_ROOM_FIELD : "rid",
+	typeField: process.env.JOB_TYPE_FIELD ? process.env.JOB_TYPE_FIELD : "type",
+	maxRetries: Number(process.env.JOB_MAX_TRY ?? 5),
 });
 
 const worker = new SnapshotWorker({
-    consumer,
-    service,
-    blockMs: Number(process.env.JOB_BLOCK_MS ?? 10000),
-    count: Number(process.env.JOB_COUNT ?? 1),
+	consumer,
+	service,
+	blockMs: Number(process.env.JOB_BLOCK_MS ?? 10000),
+	count: Number(process.env.JOB_COUNT ?? 1),
 });
 
 async function main() {
-    await worker.init();
-    await worker.start();
+	await worker.init();
+	await worker.start();
 }
 
 main();
 
-process.on('SIGINT', async () => {
-    worker.stop();
-    await redis.quit();
-    process.exit(0);
+process.on("SIGINT", async () => {
+	worker.stop();
+	await redis.quit();
+	process.exit(0);
 });
 
-process.on('SIGTERM', async () => {
-    worker.stop();
-    await redis.quit();
-    process.exit(0);
+process.on("SIGTERM", async () => {
+	worker.stop();
+	await redis.quit();
+	process.exit(0);
 });

--- a/backend/yjs-runner/app/src/server.ts
+++ b/backend/yjs-runner/app/src/server.ts
@@ -11,6 +11,7 @@ import { MindmapTicketIssuer } from "./infrastructure/MindmapTicketIssuer";
 const redis = new Redis({
 	host: process.env.REDIS_HOST!,
 	port: Number(process.env.REDIS_PORT ?? 6379),
+	password: process.env.REDIS_PASSWORD,
 });
 
 const updateRepo = new RedisUpdateRepository(redis, {

--- a/backend/yjs-runner/app/src/services/SnapshotService.ts
+++ b/backend/yjs-runner/app/src/services/SnapshotService.ts
@@ -5,37 +5,31 @@ import { Job, JobType } from "../contracts/Job";
 import { WebsocketSyncClient } from "../infrastructure/WebsocketSyncClient";
 
 export class SnapshotService {
-	constructor(
-		private readonly deps: {
-			updateRepo: UpdateRepository;
-			yjs: YjsProcessor;
-			storage: SnapshotStorage;
-			syncClient: WebsocketSyncClient;
-		},
-	) {}
+    constructor(
+        private readonly deps: {
+            updateRepo: UpdateRepository;
+            yjs: YjsProcessor;
+            storage: SnapshotStorage;
+            syncClient: WebsocketSyncClient;
+        },
+    ) {}
 
-	async process(job: Job): Promise<void> {
-		const baseSnapshot = await this.deps.storage.download(job.roomId);
-		const updates = await this.deps.updateRepo.fetchAllUpdates(job.roomId);
+    async process(job: Job): Promise<void> {
+        const baseSnapshot = await this.deps.storage.download(job.roomId);
+        const updates = await this.deps.updateRepo.fetchAllUpdates(job.roomId);
 
-		if (job.type === JobType.SNAPSHOT) {
-			const newSnapshot = this.deps.yjs.buildUpdatedSnapshot(
-				baseSnapshot,
-				updates.updateFrameList,
-			);
-			await this.deps.storage.upload(job.roomId, newSnapshot);
-			await this.deps.updateRepo.trim(job.roomId, updates.lastEntryId);
-		} else if (job.type === JobType.SYNC) {
-			let doc = this.deps.yjs.getUpdatedYDocFromSnapshot(
-				baseSnapshot,
-				updates.updateFrameList,
-			);
+        if (job.type === JobType.SNAPSHOT) {
+            const newSnapshot = this.deps.yjs.buildUpdatedSnapshot(baseSnapshot, updates.updateFrameList);
+            await this.deps.storage.upload(job.roomId, newSnapshot);
+            await this.deps.updateRepo.trim(job.roomId, updates.lastEntryId);
+        } else if (job.type === JobType.SYNC) {
+            let doc = this.deps.yjs.getUpdatedYDocFromSnapshot(baseSnapshot, updates.updateFrameList);
 
-			doc = await this.deps.syncClient.sync(doc, job.roomId);
+            doc = await this.deps.syncClient.sync(doc, job.roomId);
 
-			const newSnapshot = this.deps.yjs.getSnapshotFromDoc(doc);
-			await this.deps.storage.upload(job.roomId, newSnapshot);
-			await this.deps.updateRepo.trim(job.roomId, updates.lastEntryId);
-		}
-	}
+            const newSnapshot = this.deps.yjs.getSnapshotFromDoc(doc);
+            await this.deps.storage.upload(job.roomId, newSnapshot);
+            await this.deps.updateRepo.trim(job.roomId, updates.lastEntryId);
+        }
+    }
 }

--- a/backend/yjs-runner/app/src/services/SnapshotService.ts
+++ b/backend/yjs-runner/app/src/services/SnapshotService.ts
@@ -32,8 +32,10 @@ export class SnapshotService {
 			);
 
 			doc = await this.deps.syncClient.sync(doc, job.roomId);
+
 			const newSnapshot = this.deps.yjs.getSnapshotFromDoc(doc);
 			await this.deps.storage.upload(job.roomId, newSnapshot);
+			await this.deps.updateRepo.trim(job.roomId, updates.lastEntryId);
 		}
 	}
 }

--- a/backend/yjs-runner/app/src/services/SnapshotService.ts
+++ b/backend/yjs-runner/app/src/services/SnapshotService.ts
@@ -1,27 +1,39 @@
-import type {UpdateRepository} from '../infrastructure/UpdateRepository';
-import type {SnapshotStorage} from '../infrastructure/S3SnapshotStorage';
-import type {YjsProcessor} from '../domain/YjsProcessor';
-import {Job, JobType} from "../contracts/Job";
+import type { UpdateRepository } from "../infrastructure/UpdateRepository";
+import type { SnapshotStorage } from "../infrastructure/S3SnapshotStorage";
+import type { YjsProcessor } from "../domain/YjsProcessor";
+import { Job, JobType } from "../contracts/Job";
+import { WebsocketSyncClient } from "../infrastructure/WebsocketSyncClient";
 
 export class SnapshotService {
-    constructor(
-        private readonly deps: {
-            updateRepo: UpdateRepository;
-            yjs: YjsProcessor;
-            storage: SnapshotStorage;
-        }
-    ) {
-    }
+	constructor(
+		private readonly deps: {
+			updateRepo: UpdateRepository;
+			yjs: YjsProcessor;
+			storage: SnapshotStorage;
+			syncClient: WebsocketSyncClient;
+		},
+	) {}
 
-    async process(job: Job): Promise<void> {
-        if (job.type === JobType.SNAPSHOT) {
-            const baseDoc = await this.deps.storage.download(job.roomId)
-            const updates = await this.deps.updateRepo.fetchAllUpdates(job.roomId);
-            const newDoc = this.deps.yjs.buildSnapshot(baseDoc, updates.updateFrameList);
-            await this.deps.storage.upload(job.roomId, newDoc);
-            await this.deps.updateRepo.trim(job.roomId, updates.lastEntryId);
-        } else {
-            // todo: sync 처리 필요
-        }
-    }
+	async process(job: Job): Promise<void> {
+		const baseSnapshot = await this.deps.storage.download(job.roomId);
+		const updates = await this.deps.updateRepo.fetchAllUpdates(job.roomId);
+
+		if (job.type === JobType.SNAPSHOT) {
+			const newSnapshot = this.deps.yjs.buildUpdatedSnapshot(
+				baseSnapshot,
+				updates.updateFrameList,
+			);
+			await this.deps.storage.upload(job.roomId, newSnapshot);
+			await this.deps.updateRepo.trim(job.roomId, updates.lastEntryId);
+		} else if (job.type === JobType.SYNC) {
+			let doc = this.deps.yjs.getUpdatedYDocFromSnapshot(
+				baseSnapshot,
+				updates.updateFrameList,
+			);
+
+			doc = await this.deps.syncClient.sync(doc, job.roomId);
+			const newSnapshot = this.deps.yjs.getSnapshotFromDoc(doc);
+			await this.deps.storage.upload(job.roomId, newSnapshot);
+		}
+	}
 }

--- a/backend/yjs-runner/app/src/worker/SnapshotWorker.ts
+++ b/backend/yjs-runner/app/src/worker/SnapshotWorker.ts
@@ -1,50 +1,63 @@
-import type {JobConsumer} from '../infrastructure/JobConsumer';
-import type {SnapshotService} from '../services/SnapshotService';
+import type { JobConsumer } from "../infrastructure/JobConsumer";
+import type { SnapshotService } from "../services/SnapshotService";
 import wait from "waait";
 
 export class SnapshotWorker {
-    private running = false;
+	private running = false;
 
-    constructor(
-        private readonly deps: {
-            consumer: JobConsumer;
-            service: SnapshotService;
-            blockMs: number;
-            count?: number;
-        }
-    ) {
-    }
+	constructor(
+		private readonly deps: {
+			consumer: JobConsumer;
+			service: SnapshotService;
+			blockMs: number;
+			count?: number;
+		},
+	) {}
 
-    async init(): Promise<void> {
-        await this.deps.consumer.init();
-    }
+	async init(): Promise<void> {
+		await this.deps.consumer.init();
+	}
 
-    async start(): Promise<void> {
-        this.running = true;
+	async start(): Promise<void> {
+		this.running = true;
 
-        while (this.running) {
-            try {
-                const jobs = await this.deps.consumer.read(this.deps.blockMs, this.deps.count);
-                if (!jobs || jobs.length === 0) {
-                    continue;
-                }
-                for (const job of jobs) {
-                    try {
-                        await this.deps.service.process(job);
-                        await this.deps.consumer.ack([job.entryId]);
-                    } catch (error) {
-                        console.error(`[Worker] 저장 실패! roomId: ${job.roomId}`, error);
-                    }
-                }
-                await wait(3000); //todo: redis block 관련 로직 구현 후 삭제
-            } catch (e) {
-                console.error('[Worker] 전역 Error:', e);
-                await wait(this.deps.blockMs);
-            }
-        }
-    }
+		while (this.running) {
+			try {
+				const jobs = await this.deps.consumer.read(
+					this.deps.blockMs,
+					this.deps.count,
+				);
+				if (!jobs || jobs.length === 0) continue;
 
-    stop(): void {
-        this.running = false;
-    }
+				const successIds: string[] = [];
+
+				for (const job of jobs) {
+					try {
+						await this.deps.service.process(job);
+						successIds.push(job.entryId);
+						console.log(
+							`[Worker] ${job.type} Job 처리 완료 entryId: ${job.entryId}  roomId: ${job.roomId}`,
+						);
+					} catch (error) {
+						console.error(
+							`[Worker] ${job.type} Job 처리 실패! entryId: ${job.entryId}  roomId: ${job.roomId}`,
+							error,
+						);
+					}
+				}
+
+				if (successIds.length) {
+					await this.deps.consumer.ack(successIds);
+					await this.deps.consumer.del(successIds);
+				}
+			} catch (e) {
+				console.error("[Worker] 전역 Error:", e);
+				await wait(this.deps.blockMs);
+			}
+		}
+	}
+
+	stop(): void {
+		this.running = false;
+	}
 }

--- a/backend/yjs-runner/app/src/worker/SnapshotWorker.ts
+++ b/backend/yjs-runner/app/src/worker/SnapshotWorker.ts
@@ -3,61 +3,58 @@ import type { SnapshotService } from "../services/SnapshotService";
 import wait from "waait";
 
 export class SnapshotWorker {
-	private running = false;
+    private running = false;
 
-	constructor(
-		private readonly deps: {
-			consumer: JobConsumer;
-			service: SnapshotService;
-			blockMs: number;
-			count?: number;
-		},
-	) {}
+    constructor(
+        private readonly deps: {
+            consumer: JobConsumer;
+            service: SnapshotService;
+            blockMs: number;
+            count?: number;
+        },
+    ) {}
 
-	async init(): Promise<void> {
-		await this.deps.consumer.init();
-	}
+    async init(): Promise<void> {
+        await this.deps.consumer.init();
+    }
 
-	async start(): Promise<void> {
-		this.running = true;
+    async start(): Promise<void> {
+        this.running = true;
 
-		while (this.running) {
-			try {
-				const jobs = await this.deps.consumer.read(
-					this.deps.blockMs,
-					this.deps.count,
-				);
-				if (!jobs || jobs.length === 0) continue;
+        while (this.running) {
+            try {
+                const jobs = await this.deps.consumer.read(this.deps.blockMs, this.deps.count);
+                if (!jobs || jobs.length === 0) continue;
 
-				const successIds: string[] = [];
+                const successIds: string[] = [];
 
-				for (const job of jobs) {
-					try {
-						await this.deps.service.process(job);
-						successIds.push(job.entryId);
-						console.log(
-							`[Worker] ${job.type} Job 처리 완료 entryId: ${job.entryId}  roomId: ${job.roomId}`,
-						);
-					} catch (error) {
-						console.error(
-							`[Worker] ${job.type} Job 처리 실패! entryId: ${job.entryId}  roomId: ${job.roomId}`,
-							error,
-						);
-					}
-				}
+                for (const job of jobs) {
+                    try {
+                        await this.deps.service.process(job);
+                        successIds.push(job.entryId);
+                        console.log(
+                            `[Worker] ${job.type} Job 처리 완료 entryId: ${job.entryId}  roomId: ${job.roomId}`,
+                        );
+                    } catch (error) {
+                        console.error(
+                            `[Worker] ${job.type} Job 처리 실패! entryId: ${job.entryId}  roomId: ${job.roomId}`,
+                            error,
+                        );
+                    }
+                }
 
-				if (successIds.length) {
-					await this.deps.consumer.ack(successIds);
-					await this.deps.consumer.del(successIds);
-				}
-			} catch (e) {
-				console.error("[Worker] 전역 Error:", e);
-				await wait(this.deps.blockMs);
-			}
-		}
-	}
+                if (successIds.length) {
+                    await this.deps.consumer.ack(successIds);
+                    await this.deps.consumer.del(successIds);
+                }
+            } catch (e) {
+                console.error("[Worker] 전역 Error:", e);
+                await wait(this.deps.blockMs);
+            }
+        }
+    }
 
-	stop(): void {
-		this.running = false;
-	}
+    stop(): void {
+        this.running = false;
+    }
 }

--- a/backend/yjs-runner/app/test/integration/JobConsumer.int.spec.ts
+++ b/backend/yjs-runner/app/test/integration/JobConsumer.int.spec.ts
@@ -1,34 +1,32 @@
-import Redis from 'ioredis';
-import {GenericContainer, StartedTestContainer} from "testcontainers";
-import {RedisStreamJobConsumer} from "../../src/infrastructure/JobConsumer";
+import Redis from "ioredis";
+import { GenericContainer, StartedTestContainer } from "testcontainers";
+import { RedisStreamJobConsumer } from "../../src/infrastructure/JobConsumer";
 
-describe('RedisStreamJobConsumer Integration Test', () => {
+describe("RedisStreamJobConsumer Integration Test", () => {
     let redisContainer: StartedTestContainer;
     let redis: Redis;
     let consumer: RedisStreamJobConsumer;
 
-    const STREAM_KEY = 'test:jobs';
-    const DEDUPE_KEY = 'test:jobs:dedupe:'
-    const GROUP_NAME = 'test-group';
-    const CONSUMER_NAME = 'test-worker';
+    const STREAM_KEY = "test:jobs";
+    const DEDUPE_KEY = "test:jobs:dedupe:";
+    const GROUP_NAME = "test-group";
+    const CONSUMER_NAME = "test-worker";
 
     beforeAll(async () => {
-        redisContainer = await new GenericContainer("redis:7-alpine")
-            .withExposedPorts(6379)
-            .start();
+        redisContainer = await new GenericContainer("redis:7-alpine").withExposedPorts(6379).start();
 
         const host = redisContainer.getHost();
         const port = redisContainer.getMappedPort(6379);
-        redis = new Redis({host, port});
+        redis = new Redis({ host, port });
 
         consumer = new RedisStreamJobConsumer(redis, {
             jobStreamKey: STREAM_KEY,
             jobDedupePrefix: DEDUPE_KEY,
             groupName: GROUP_NAME,
             consumerName: CONSUMER_NAME,
-            roomIdField: 'rid',
-            typeField: 'type',
-            maxRetries: 5
+            roomIdField: "rid",
+            typeField: "type",
+            maxRetries: 5,
         });
 
         await consumer.init();
@@ -44,15 +42,9 @@ describe('RedisStreamJobConsumer Integration Test', () => {
         await consumer.init();
     });
 
-    it('메시지를 발행하면 Read를 통해 Job 형태로 읽어와야 한다', async () => {
-        const testRoomId = 'room-123';
-        await redis.xadd(
-            STREAM_KEY,
-            '*',
-            'rid', testRoomId,
-            'type', 'SNAPSHOT'
-        );
-
+    it("메시지를 발행하면 Read를 통해 Job 형태로 읽어와야 한다", async () => {
+        const testRoomId = "room-123";
+        await redis.xadd(STREAM_KEY, "*", "rid", testRoomId, "type", "SNAPSHOT");
 
         const jobs = await consumer.read(1000, 1);
 
@@ -61,14 +53,9 @@ describe('RedisStreamJobConsumer Integration Test', () => {
         expect(jobs[0].entryId).toBeDefined();
     });
 
-    it('ACK를 보내면 해당 메시지는 PEL(Pending List)에서 제거되어야 한다', async () => {
-        const testRoomId = 'room-456';
-        await redis.xadd(
-            STREAM_KEY,
-            '*',
-            'rid', testRoomId,
-            'type', 'SNAPSHOT'
-        );
+    it("ACK를 보내면 해당 메시지는 PEL(Pending List)에서 제거되어야 한다", async () => {
+        const testRoomId = "room-456";
+        await redis.xadd(STREAM_KEY, "*", "rid", testRoomId, "type", "SNAPSHOT");
 
         const jobs = await consumer.read(1000, 1);
         const messageId = jobs[0].entryId;
@@ -82,14 +69,14 @@ describe('RedisStreamJobConsumer Integration Test', () => {
         expect(Number(pendingAfter[0])).toBe(0);
     });
 
-    it('데이터가 없을 때 Read를 호출하면 빈 배열을 반환해야 한다', async () => {
+    it("데이터가 없을 때 Read를 호출하면 빈 배열을 반환해야 한다", async () => {
         const jobs = await consumer.read(100, 1); // 짧게 100ms만 대기
         expect(jobs).toEqual([]);
     });
 
-    it('재시도 횟수(maxRetries)를 초과한 메시지는 자동으로 ACK 처리되고 읽히지 않아야 한다', async () => {
-        const testRoomId = 'poison-pill-room';
-        const messageId = await redis.xadd(STREAM_KEY, '*', 'r', testRoomId);
+    it("재시도 횟수(maxRetries)를 초과한 메시지는 자동으로 ACK 처리되고 읽히지 않아야 한다", async () => {
+        const testRoomId = "poison-pill-room";
+        const messageId = await redis.xadd(STREAM_KEY, "*", "r", testRoomId);
 
         for (let i = 0; i < 6; i++) {
             await consumer.read(100, 1);
@@ -103,14 +90,9 @@ describe('RedisStreamJobConsumer Integration Test', () => {
         expect(Number(pending[0])).toBe(0);
     });
 
-    it('PEL에 남은 메시지가 maxRetries 이내라면 정상적으로 다시 읽어와야 한다', async () => {
-        const testRoomId = 'retry-room';
-        await redis.xadd(
-            STREAM_KEY,
-            '*',
-            'rid', testRoomId,
-            'type', 'SNAPSHOT'
-        );
+    it("PEL에 남은 메시지가 maxRetries 이내라면 정상적으로 다시 읽어와야 한다", async () => {
+        const testRoomId = "retry-room";
+        await redis.xadd(STREAM_KEY, "*", "rid", testRoomId, "type", "SNAPSHOT");
         await consumer.read(100, 1);
 
         const jobs = await consumer.read(100, 1);

--- a/backend/yjs-runner/app/test/integration/SnapshotService.int.spec.ts
+++ b/backend/yjs-runner/app/test/integration/SnapshotService.int.spec.ts
@@ -1,135 +1,149 @@
-import * as Y from 'yjs';
-import {GenericContainer, StartedTestContainer} from "testcontainers";
-import Redis from 'ioredis';
-import {CreateBucketCommand, PutObjectCommand, S3Client} from "@aws-sdk/client-s3";
-import {SnapshotService} from "../../src/services/SnapshotService";
-import {RedisUpdateRepository} from "../../src/infrastructure/UpdateRepository";
-import {S3SnapshotStorage} from "../../src/infrastructure/S3SnapshotStorage";
-import {DefaultYjsProcessor} from "../../src/domain/YjsProcessor";
-import {encoding} from "lib0";
-import {JobType} from "../../src/contracts/Job";
+import * as Y from "yjs";
+import { GenericContainer, StartedTestContainer } from "testcontainers";
+import Redis from "ioredis";
+import {
+	CreateBucketCommand,
+	PutObjectCommand,
+	S3Client,
+} from "@aws-sdk/client-s3";
+import { SnapshotService } from "../../src/services/SnapshotService";
+import { RedisUpdateRepository } from "../../src/infrastructure/UpdateRepository";
+import { S3SnapshotStorage } from "../../src/infrastructure/S3SnapshotStorage";
+import { DefaultYjsProcessor } from "../../src/domain/YjsProcessor";
+import * as encoding from "lib0/encoding";
+import { JobType } from "../../src/contracts/Job";
+import type { WebsocketSyncClient } from "../../src/infrastructure/WebsocketSyncClient";
 
+describe("SnapshotService Integration Test (Testcontainers)", () => {
+	let redisContainer: StartedTestContainer;
+	let minioContainer: StartedTestContainer;
 
-describe('SnapshotService Integration Test (Testcontainers)', () => {
-    let redisContainer: StartedTestContainer;
-    let minioContainer: StartedTestContainer;
+	let redis: Redis;
+	let s3Client: S3Client;
+	let service: SnapshotService;
+	let storage: S3SnapshotStorage;
 
-    let redis: Redis;
-    let s3Client: S3Client;
-    let service: SnapshotService;
-    let storage: S3SnapshotStorage;
+	const BUCKET_NAME = "episode-test-bucket";
+	const ROOM_ID = "test-room-999";
 
-    const BUCKET_NAME = 'episode-test-bucket';
-    const ROOM_ID = 'test-room-999';
+	beforeAll(async () => {
+		redisContainer = await new GenericContainer("redis:7-alpine")
+			.withExposedPorts(6379)
+			.start();
 
-    beforeAll(async () => {
-        redisContainer = await new GenericContainer("redis:7-alpine")
-            .withExposedPorts(6379)
-            .start();
+		minioContainer = await new GenericContainer("minio/minio")
+			.withExposedPorts(9000)
+			.withCommand(["server", "/data"])
+			.start();
 
-        minioContainer = await new GenericContainer("minio/minio")
-            .withExposedPorts(9000)
-            .withCommand(["server", "/data"])
-            .start();
+		const redisHost = redisContainer.getHost();
+		const redisPort = redisContainer.getMappedPort(6379);
+		const minioHost = minioContainer.getHost();
+		const minioPort = minioContainer.getMappedPort(9000);
 
-        const redisHost = redisContainer.getHost();
-        const redisPort = redisContainer.getMappedPort(6379);
-        const minioHost = minioContainer.getHost();
-        const minioPort = minioContainer.getMappedPort(9000);
+		redis = new Redis({ host: redisHost, port: redisPort });
 
-        redis = new Redis({host: redisHost, port: redisPort});
+		const s3Config = {
+			region: "us-east-1",
+			endpoint: `http://${minioHost}:${minioPort}`,
+			forcePathStyle: true,
+			credentials: { accessKeyId: "minioadmin", secretAccessKey: "minioadmin" },
+		};
+		s3Client = new S3Client(s3Config);
 
-        const s3Config = {
-            region: 'us-east-1',
-            endpoint: `http://${minioHost}:${minioPort}`,
-            forcePathStyle: true,
-            credentials: {accessKeyId: 'minioadmin', secretAccessKey: 'minioadmin'}
-        };
-        s3Client = new S3Client(s3Config);
+		await s3Client.send(new CreateBucketCommand({ Bucket: BUCKET_NAME }));
 
-        await s3Client.send(new CreateBucketCommand({Bucket: BUCKET_NAME}));
+		storage = new S3SnapshotStorage({
+			...s3Config,
+			bucket: BUCKET_NAME,
+			keyPrefix: "snapshots/",
+			accessKey: "minioadmin",
+			secretKey: "minioadmin",
+		});
 
-        storage = new S3SnapshotStorage({
-            ...s3Config,
-            bucket: BUCKET_NAME,
-            keyPrefix: 'snapshots/',
-            accessKey: 'minioadmin',
-            secretKey: 'minioadmin'
-        });
+		const syncClient = {
+			sync: async (doc: Y.Doc) => doc,
+		} as unknown as WebsocketSyncClient;
 
-        const updateRepo = new RedisUpdateRepository(redis, {
-            updateStreamKeyPrefix: 'updates:'
-        });
+		const updateRepo = new RedisUpdateRepository(redis, {
+			updateStreamKeyPrefix: "updates:",
+		});
 
-        service = new SnapshotService({
-            updateRepo,
-            storage,
-            yjs: new DefaultYjsProcessor()
-        });
-    }, 60000);
+		service = new SnapshotService({
+			updateRepo,
+			storage,
+			yjs: new DefaultYjsProcessor(),
+			syncClient,
+		});
+	}, 60000);
 
-    afterAll(async () => {
-        if (redis) await redis.quit();
-        if (redisContainer) await redisContainer.stop();
-        if (minioContainer) await minioContainer.stop();
-    });
+	afterAll(async () => {
+		if (redis) await redis.quit();
+		if (redisContainer) await redisContainer.stop();
+		if (minioContainer) await minioContainer.stop();
+	});
 
+	it("성공: S3 base + Redis updates 병합 후 S3 저장, Redis stream 비움", async () => {
+		const streamKey = `updates:${ROOM_ID}`;
+		const s3Key = `snapshots/${ROOM_ID}`;
 
-    it('성공 케이스: S3에 베이스가 있을 때 Redis 업데이트를 병합하여 저장하고 Redis를 비워야 한다', async () => {
-        const streamKey = `updates:${ROOM_ID}`;
-        const s3Key = `snapshots/${ROOM_ID}`;
+		const baseDoc = new Y.Doc();
+		baseDoc.getText("test").insert(0, "hello");
+		const baseSnapshot = Y.encodeStateAsUpdate(baseDoc);
 
-        const ydoc = new Y.Doc();
-        const ytext = ydoc.getText('test');
-        ytext.insert(0, 'hello');
-        const baseSnapshot = Y.encodeStateAsUpdate(ydoc);
+		await s3Client.send(
+			new PutObjectCommand({
+				Bucket: BUCKET_NAME,
+				Key: s3Key,
+				Body: baseSnapshot,
+			}),
+		);
 
-        await s3Client.send(new PutObjectCommand({
-            Bucket: BUCKET_NAME,
-            Key: s3Key,
-            Body: baseSnapshot
-        }));
+		const updatedDoc = new Y.Doc();
+		Y.applyUpdate(updatedDoc, baseSnapshot);
+		updatedDoc.getText("test").insert(5, " world");
 
-        const updateDoc = new Y.Doc();
-        const updateText = updateDoc.getText('test');
-        updateText.insert(5, ' world');
-        const dummyUpdate = Y.encodeStateAsUpdate(updateDoc);
+		const diffUpdate = Y.encodeStateAsUpdate(
+			updatedDoc,
+			Y.encodeStateVector(baseDoc),
+		);
 
-        const enc = encoding.createEncoder();
-        encoding.writeVarUint(enc, 0);
-        encoding.writeVarUint(enc, 2);
-        encoding.writeVarUint8Array(enc, dummyUpdate);
+		const enc = encoding.createEncoder();
+		encoding.writeVarUint(enc, 0);
+		encoding.writeVarUint(enc, 2);
+		encoding.writeVarUint8Array(enc, diffUpdate);
+		const framed = encoding.toUint8Array(enc);
 
-        const framed = encoding.toUint8Array(enc);
+		await redis.xadd(streamKey, "*", "u", Buffer.from(framed));
 
-        await redis.xadd(streamKey, '*', 'u', Buffer.from(framed));
+		await service.process({
+			entryId: "test-entry",
+			roomId: ROOM_ID,
+			type: JobType.SNAPSHOT,
+		});
 
-        await service.process({
-            entryId: 'test-entry',
-            roomId: ROOM_ID,
-            type: JobType.SNAPSHOT
-        });
+		const remaining = await redis.xlen(streamKey);
+		expect(remaining).toBe(0);
 
-        const remaining = await redis.xrange(streamKey, '-', '+');
-        expect(remaining.length).toBe(0);
-        const downloaded = await storage.download(ROOM_ID);
+		const downloaded = await storage.download(ROOM_ID);
 
-        expect(downloaded).not.toEqual(baseSnapshot);
-        expect(downloaded.length).toBeGreaterThan(0);
-    });
+		const outDoc = new Y.Doc();
+		Y.applyUpdate(outDoc, downloaded);
+		expect(outDoc.getText("test").toString()).toBe("hello world");
+	});
 
-    it('S3에 베이스 데이터가 없으면 에러가 발생해야 한다', async () => {
-        const noBaseRoomId = 'no-base-room';
-        const streamKey = `updates:${noBaseRoomId}`;
+	it("S3 base 없으면 에러", async () => {
+		const noBaseRoomId = "no-base-room";
+		const streamKey = `updates:${noBaseRoomId}`;
 
-        await redis.xadd(streamKey, '*', 'u', Buffer.from([1, 2]));
+		await redis.xadd(streamKey, "*", "u", Buffer.from([1, 2]));
 
-        await expect(
-            service.process({
-                entryId: 'test-entry',
-                roomId: noBaseRoomId,
-                type: JobType.SNAPSHOT
-            })
-        ).rejects.toThrow();
-    });
+		await expect(
+			service.process({
+				entryId: "test-entry",
+				roomId: noBaseRoomId,
+				type: JobType.SNAPSHOT,
+			}),
+		).rejects.toThrow();
+	});
 });

--- a/backend/yjs-runner/app/test/integration/SnapshotService.int.spec.ts
+++ b/backend/yjs-runner/app/test/integration/SnapshotService.int.spec.ts
@@ -1,11 +1,7 @@
 import * as Y from "yjs";
 import { GenericContainer, StartedTestContainer } from "testcontainers";
 import Redis from "ioredis";
-import {
-	CreateBucketCommand,
-	PutObjectCommand,
-	S3Client,
-} from "@aws-sdk/client-s3";
+import { CreateBucketCommand, PutObjectCommand, S3Client } from "@aws-sdk/client-s3";
 import { SnapshotService } from "../../src/services/SnapshotService";
 import { RedisUpdateRepository } from "../../src/infrastructure/UpdateRepository";
 import { S3SnapshotStorage } from "../../src/infrastructure/S3SnapshotStorage";
@@ -15,135 +11,130 @@ import { JobType } from "../../src/contracts/Job";
 import type { WebsocketSyncClient } from "../../src/infrastructure/WebsocketSyncClient";
 
 describe("SnapshotService Integration Test (Testcontainers)", () => {
-	let redisContainer: StartedTestContainer;
-	let minioContainer: StartedTestContainer;
+    let redisContainer: StartedTestContainer;
+    let minioContainer: StartedTestContainer;
 
-	let redis: Redis;
-	let s3Client: S3Client;
-	let service: SnapshotService;
-	let storage: S3SnapshotStorage;
+    let redis: Redis;
+    let s3Client: S3Client;
+    let service: SnapshotService;
+    let storage: S3SnapshotStorage;
 
-	const BUCKET_NAME = "episode-test-bucket";
-	const ROOM_ID = "test-room-999";
+    const BUCKET_NAME = "episode-test-bucket";
+    const ROOM_ID = "test-room-999";
 
-	beforeAll(async () => {
-		redisContainer = await new GenericContainer("redis:7-alpine")
-			.withExposedPorts(6379)
-			.start();
+    beforeAll(async () => {
+        redisContainer = await new GenericContainer("redis:7-alpine").withExposedPorts(6379).start();
 
-		minioContainer = await new GenericContainer("minio/minio")
-			.withExposedPorts(9000)
-			.withCommand(["server", "/data"])
-			.start();
+        minioContainer = await new GenericContainer("minio/minio")
+            .withExposedPorts(9000)
+            .withCommand(["server", "/data"])
+            .start();
 
-		const redisHost = redisContainer.getHost();
-		const redisPort = redisContainer.getMappedPort(6379);
-		const minioHost = minioContainer.getHost();
-		const minioPort = minioContainer.getMappedPort(9000);
+        const redisHost = redisContainer.getHost();
+        const redisPort = redisContainer.getMappedPort(6379);
+        const minioHost = minioContainer.getHost();
+        const minioPort = minioContainer.getMappedPort(9000);
 
-		redis = new Redis({ host: redisHost, port: redisPort });
+        redis = new Redis({ host: redisHost, port: redisPort });
 
-		const s3Config = {
-			region: "us-east-1",
-			endpoint: `http://${minioHost}:${minioPort}`,
-			forcePathStyle: true,
-			credentials: { accessKeyId: "minioadmin", secretAccessKey: "minioadmin" },
-		};
-		s3Client = new S3Client(s3Config);
+        const s3Config = {
+            region: "us-east-1",
+            endpoint: `http://${minioHost}:${minioPort}`,
+            forcePathStyle: true,
+            credentials: { accessKeyId: "minioadmin", secretAccessKey: "minioadmin" },
+        };
+        s3Client = new S3Client(s3Config);
 
-		await s3Client.send(new CreateBucketCommand({ Bucket: BUCKET_NAME }));
+        await s3Client.send(new CreateBucketCommand({ Bucket: BUCKET_NAME }));
 
-		storage = new S3SnapshotStorage({
-			...s3Config,
-			bucket: BUCKET_NAME,
-			keyPrefix: "snapshots/",
-			accessKey: "minioadmin",
-			secretKey: "minioadmin",
-		});
+        storage = new S3SnapshotStorage({
+            ...s3Config,
+            bucket: BUCKET_NAME,
+            keyPrefix: "snapshots/",
+            accessKey: "minioadmin",
+            secretKey: "minioadmin",
+        });
 
-		const syncClient = {
-			sync: async (doc: Y.Doc) => doc,
-		} as unknown as WebsocketSyncClient;
+        const syncClient = {
+            sync: async (doc: Y.Doc) => doc,
+        } as unknown as WebsocketSyncClient;
 
-		const updateRepo = new RedisUpdateRepository(redis, {
-			updateStreamKeyPrefix: "updates:",
-		});
+        const updateRepo = new RedisUpdateRepository(redis, {
+            updateStreamKeyPrefix: "updates:",
+        });
 
-		service = new SnapshotService({
-			updateRepo,
-			storage,
-			yjs: new DefaultYjsProcessor(),
-			syncClient,
-		});
-	}, 60000);
+        service = new SnapshotService({
+            updateRepo,
+            storage,
+            yjs: new DefaultYjsProcessor(),
+            syncClient,
+        });
+    }, 60000);
 
-	afterAll(async () => {
-		if (redis) await redis.quit();
-		if (redisContainer) await redisContainer.stop();
-		if (minioContainer) await minioContainer.stop();
-	});
+    afterAll(async () => {
+        if (redis) await redis.quit();
+        if (redisContainer) await redisContainer.stop();
+        if (minioContainer) await minioContainer.stop();
+    });
 
-	it("성공: S3 base + Redis updates 병합 후 S3 저장, Redis stream 비움", async () => {
-		const streamKey = `updates:${ROOM_ID}`;
-		const s3Key = `snapshots/${ROOM_ID}`;
+    it("성공: S3 base + Redis updates 병합 후 S3 저장, Redis stream 비움", async () => {
+        const streamKey = `updates:${ROOM_ID}`;
+        const s3Key = `snapshots/${ROOM_ID}`;
 
-		const baseDoc = new Y.Doc();
-		baseDoc.getText("test").insert(0, "hello");
-		const baseSnapshot = Y.encodeStateAsUpdate(baseDoc);
+        const baseDoc = new Y.Doc();
+        baseDoc.getText("test").insert(0, "hello");
+        const baseSnapshot = Y.encodeStateAsUpdate(baseDoc);
 
-		await s3Client.send(
-			new PutObjectCommand({
-				Bucket: BUCKET_NAME,
-				Key: s3Key,
-				Body: baseSnapshot,
-			}),
-		);
+        await s3Client.send(
+            new PutObjectCommand({
+                Bucket: BUCKET_NAME,
+                Key: s3Key,
+                Body: baseSnapshot,
+            }),
+        );
 
-		const updatedDoc = new Y.Doc();
-		Y.applyUpdate(updatedDoc, baseSnapshot);
-		updatedDoc.getText("test").insert(5, " world");
+        const updatedDoc = new Y.Doc();
+        Y.applyUpdate(updatedDoc, baseSnapshot);
+        updatedDoc.getText("test").insert(5, " world");
 
-		const diffUpdate = Y.encodeStateAsUpdate(
-			updatedDoc,
-			Y.encodeStateVector(baseDoc),
-		);
+        const diffUpdate = Y.encodeStateAsUpdate(updatedDoc, Y.encodeStateVector(baseDoc));
 
-		const enc = encoding.createEncoder();
-		encoding.writeVarUint(enc, 0);
-		encoding.writeVarUint(enc, 2);
-		encoding.writeVarUint8Array(enc, diffUpdate);
-		const framed = encoding.toUint8Array(enc);
+        const enc = encoding.createEncoder();
+        encoding.writeVarUint(enc, 0);
+        encoding.writeVarUint(enc, 2);
+        encoding.writeVarUint8Array(enc, diffUpdate);
+        const framed = encoding.toUint8Array(enc);
 
-		await redis.xadd(streamKey, "*", "u", Buffer.from(framed));
+        await redis.xadd(streamKey, "*", "u", Buffer.from(framed));
 
-		await service.process({
-			entryId: "test-entry",
-			roomId: ROOM_ID,
-			type: JobType.SNAPSHOT,
-		});
+        await service.process({
+            entryId: "test-entry",
+            roomId: ROOM_ID,
+            type: JobType.SNAPSHOT,
+        });
 
-		const remaining = await redis.xlen(streamKey);
-		expect(remaining).toBe(0);
+        const remaining = await redis.xlen(streamKey);
+        expect(remaining).toBe(0);
 
-		const downloaded = await storage.download(ROOM_ID);
+        const downloaded = await storage.download(ROOM_ID);
 
-		const outDoc = new Y.Doc();
-		Y.applyUpdate(outDoc, downloaded);
-		expect(outDoc.getText("test").toString()).toBe("hello world");
-	});
+        const outDoc = new Y.Doc();
+        Y.applyUpdate(outDoc, downloaded);
+        expect(outDoc.getText("test").toString()).toBe("hello world");
+    });
 
-	it("S3 base 없으면 에러", async () => {
-		const noBaseRoomId = "no-base-room";
-		const streamKey = `updates:${noBaseRoomId}`;
+    it("S3 base 없으면 에러", async () => {
+        const noBaseRoomId = "no-base-room";
+        const streamKey = `updates:${noBaseRoomId}`;
 
-		await redis.xadd(streamKey, "*", "u", Buffer.from([1, 2]));
+        await redis.xadd(streamKey, "*", "u", Buffer.from([1, 2]));
 
-		await expect(
-			service.process({
-				entryId: "test-entry",
-				roomId: noBaseRoomId,
-				type: JobType.SNAPSHOT,
-			}),
-		).rejects.toThrow();
-	});
+        await expect(
+            service.process({
+                entryId: "test-entry",
+                roomId: noBaseRoomId,
+                type: JobType.SNAPSHOT,
+            }),
+        ).rejects.toThrow();
+    });
 });

--- a/backend/yjs-runner/app/test/unit/services/SnapshotService.spec.ts
+++ b/backend/yjs-runner/app/test/unit/services/SnapshotService.spec.ts
@@ -6,116 +6,108 @@ import { JobType } from "../../../src/contracts/Job";
 import { WebsocketSyncClient } from "../../../src/infrastructure/WebsocketSyncClient";
 
 describe("SnapshotService", () => {
-	let service: SnapshotService;
+    let service: SnapshotService;
 
-	const mockUpdateRepo = {
-		fetchAllUpdates: jest.fn(),
-		trim: jest.fn(),
-	} as unknown as jest.Mocked<UpdateRepository>;
+    const mockUpdateRepo = {
+        fetchAllUpdates: jest.fn(),
+        trim: jest.fn(),
+    } as unknown as jest.Mocked<UpdateRepository>;
 
-	const mockYjs = {
-		buildUpdatedSnapshot: jest.fn(),
-		getUpdatedYDocFromSnapshot: jest.fn(),
-		getSnapshotFromDoc: jest.fn(),
-	} as unknown as jest.Mocked<YjsProcessor>;
+    const mockYjs = {
+        buildUpdatedSnapshot: jest.fn(),
+        getUpdatedYDocFromSnapshot: jest.fn(),
+        getSnapshotFromDoc: jest.fn(),
+    } as unknown as jest.Mocked<YjsProcessor>;
 
-	const mockStorage = {
-		upload: jest.fn(),
-		download: jest.fn(),
-	} as unknown as jest.Mocked<SnapshotStorage>;
+    const mockStorage = {
+        upload: jest.fn(),
+        download: jest.fn(),
+    } as unknown as jest.Mocked<SnapshotStorage>;
 
-	const mockSyncClient = {
-		sync: jest.fn(),
-	} as unknown as jest.Mocked<WebsocketSyncClient>;
+    const mockSyncClient = {
+        sync: jest.fn(),
+    } as unknown as jest.Mocked<WebsocketSyncClient>;
 
-	beforeEach(() => {
-		service = new SnapshotService({
-			updateRepo: mockUpdateRepo,
-			yjs: mockYjs,
-			storage: mockStorage,
-			syncClient: mockSyncClient,
-		});
-		jest.clearAllMocks();
-	});
+    beforeEach(() => {
+        service = new SnapshotService({
+            updateRepo: mockUpdateRepo,
+            yjs: mockYjs,
+            storage: mockStorage,
+            syncClient: mockSyncClient,
+        });
+        jest.clearAllMocks();
+    });
 
-	it("성공 시나리오: 데이터를 가져와서 병합 후 업로드하고 저장소를 정리해야 한다", async () => {
-		const roomId = "test-room";
-		const mockBase = new Uint8Array([1, 2]);
-		const mockUpdates = [new Uint8Array([3]), new Uint8Array([4])];
-		const mockNewSnapshot = new Uint8Array([1, 2, 3, 4]);
+    it("성공 시나리오: 데이터를 가져와서 병합 후 업로드하고 저장소를 정리해야 한다", async () => {
+        const roomId = "test-room";
+        const mockBase = new Uint8Array([1, 2]);
+        const mockUpdates = [new Uint8Array([3]), new Uint8Array([4])];
+        const mockNewSnapshot = new Uint8Array([1, 2, 3, 4]);
 
-		const mockPacket = {
-			lastEntryId: "123-0",
-			roomId: roomId,
-			updateFrameList: mockUpdates,
-		};
+        const mockPacket = {
+            lastEntryId: "123-0",
+            roomId: roomId,
+            updateFrameList: mockUpdates,
+        };
 
-		const job = {
-			entryId: "test-entry",
-			roomId,
-			type: JobType.SNAPSHOT,
-		};
+        const job = {
+            entryId: "test-entry",
+            roomId,
+            type: JobType.SNAPSHOT,
+        };
 
-		mockStorage.download.mockResolvedValue(mockBase);
-		mockUpdateRepo.fetchAllUpdates.mockResolvedValue(mockPacket);
-		mockYjs.buildUpdatedSnapshot.mockReturnValue(mockNewSnapshot);
+        mockStorage.download.mockResolvedValue(mockBase);
+        mockUpdateRepo.fetchAllUpdates.mockResolvedValue(mockPacket);
+        mockYjs.buildUpdatedSnapshot.mockReturnValue(mockNewSnapshot);
 
-		await service.process(job);
+        await service.process(job);
 
-		expect(mockStorage.download).toHaveBeenCalledWith(roomId);
-		expect(mockUpdateRepo.fetchAllUpdates).toHaveBeenCalledWith(roomId);
-		expect(mockYjs.buildUpdatedSnapshot).toHaveBeenCalledWith(
-			mockBase,
-			mockUpdates,
-		);
-		expect(mockStorage.upload).toHaveBeenCalledWith(roomId, mockNewSnapshot);
-		expect(mockUpdateRepo.trim).toHaveBeenCalledWith(
-			roomId,
-			mockPacket.lastEntryId,
-		);
-	});
+        expect(mockStorage.download).toHaveBeenCalledWith(roomId);
+        expect(mockUpdateRepo.fetchAllUpdates).toHaveBeenCalledWith(roomId);
+        expect(mockYjs.buildUpdatedSnapshot).toHaveBeenCalledWith(mockBase, mockUpdates);
+        expect(mockStorage.upload).toHaveBeenCalledWith(roomId, mockNewSnapshot);
+        expect(mockUpdateRepo.trim).toHaveBeenCalledWith(roomId, mockPacket.lastEntryId);
+    });
 
-	it("S3에 기존 스냅샷이 없으면 에러를 던져야 한다 (NoSuchKey 등)", async () => {
-		const roomId = "no-base-room";
+    it("S3에 기존 스냅샷이 없으면 에러를 던져야 한다 (NoSuchKey 등)", async () => {
+        const roomId = "no-base-room";
 
-		mockStorage.download.mockRejectedValue(
-			new Error("NoSuchKey: The specified key does not exist."),
-		);
+        mockStorage.download.mockRejectedValue(new Error("NoSuchKey: The specified key does not exist."));
 
-		await expect(
-			service.process({
-				entryId: "test-entry",
-				roomId,
-				type: JobType.SNAPSHOT,
-			}),
-		).rejects.toThrow("NoSuchKey");
+        await expect(
+            service.process({
+                entryId: "test-entry",
+                roomId,
+                type: JobType.SNAPSHOT,
+            }),
+        ).rejects.toThrow("NoSuchKey");
 
-		expect(mockYjs.buildUpdatedSnapshot).not.toHaveBeenCalled();
-		expect(mockStorage.upload).not.toHaveBeenCalled();
-		expect(mockUpdateRepo.trim).not.toHaveBeenCalled();
-	});
+        expect(mockYjs.buildUpdatedSnapshot).not.toHaveBeenCalled();
+        expect(mockStorage.upload).not.toHaveBeenCalled();
+        expect(mockUpdateRepo.trim).not.toHaveBeenCalled();
+    });
 
-	it("업로드에 실패하면 Redis를 비우지(trim) 않아야 한다", async () => {
-		const roomId = "fail-room";
-		const lastEntryId = "456-0";
+    it("업로드에 실패하면 Redis를 비우지(trim) 않아야 한다", async () => {
+        const roomId = "fail-room";
+        const lastEntryId = "456-0";
 
-		mockStorage.download.mockResolvedValue(new Uint8Array([1]));
-		mockUpdateRepo.fetchAllUpdates.mockResolvedValue({
-			lastEntryId,
-			roomId,
-			updateFrameList: [new Uint8Array([2])],
-		});
-		mockYjs.buildUpdatedSnapshot.mockReturnValue(new Uint8Array([1, 2]));
-		mockStorage.upload.mockRejectedValue(new Error("S3 Connection Failed"));
+        mockStorage.download.mockResolvedValue(new Uint8Array([1]));
+        mockUpdateRepo.fetchAllUpdates.mockResolvedValue({
+            lastEntryId,
+            roomId,
+            updateFrameList: [new Uint8Array([2])],
+        });
+        mockYjs.buildUpdatedSnapshot.mockReturnValue(new Uint8Array([1, 2]));
+        mockStorage.upload.mockRejectedValue(new Error("S3 Connection Failed"));
 
-		await expect(
-			service.process({
-				entryId: "test-entry",
-				roomId,
-				type: JobType.SNAPSHOT,
-			}),
-		).rejects.toThrow("S3 Connection Failed");
+        await expect(
+            service.process({
+                entryId: "test-entry",
+                roomId,
+                type: JobType.SNAPSHOT,
+            }),
+        ).rejects.toThrow("S3 Connection Failed");
 
-		expect(mockUpdateRepo.trim).not.toHaveBeenCalled();
-	});
+        expect(mockUpdateRepo.trim).not.toHaveBeenCalled();
+    });
 });

--- a/backend/yjs-runner/app/test/unit/services/SnapshotService.spec.ts
+++ b/backend/yjs-runner/app/test/unit/services/SnapshotService.spec.ts
@@ -1,101 +1,121 @@
-import {SnapshotService} from '../../../src/services/SnapshotService';
-import {UpdateRepository} from '../../../src/infrastructure/UpdateRepository';
-import {YjsProcessor} from '../../../src/domain/YjsProcessor';
-import {SnapshotStorage} from '../../../src/infrastructure/S3SnapshotStorage';
-import {JobType} from "../../../src/contracts/Job";
+import { SnapshotService } from "../../../src/services/SnapshotService";
+import { UpdateRepository } from "../../../src/infrastructure/UpdateRepository";
+import { YjsProcessor } from "../../../src/domain/YjsProcessor";
+import { SnapshotStorage } from "../../../src/infrastructure/S3SnapshotStorage";
+import { JobType } from "../../../src/contracts/Job";
+import { WebsocketSyncClient } from "../../../src/infrastructure/WebsocketSyncClient";
 
-describe('SnapshotService', () => {
-    let service: SnapshotService;
+describe("SnapshotService", () => {
+	let service: SnapshotService;
 
-    const mockUpdateRepo = {
-        fetchAllUpdates: jest.fn(),
-        trim: jest.fn(),
-    } as unknown as jest.Mocked<UpdateRepository>;
+	const mockUpdateRepo = {
+		fetchAllUpdates: jest.fn(),
+		trim: jest.fn(),
+	} as unknown as jest.Mocked<UpdateRepository>;
 
-    const mockYjs = {
-        buildSnapshot: jest.fn(),
-    } as unknown as jest.Mocked<YjsProcessor>;
+	const mockYjs = {
+		buildUpdatedSnapshot: jest.fn(),
+		getUpdatedYDocFromSnapshot: jest.fn(),
+		getSnapshotFromDoc: jest.fn(),
+	} as unknown as jest.Mocked<YjsProcessor>;
 
-    const mockStorage = {
-        upload: jest.fn(),
-        download: jest.fn(),
-    } as unknown as jest.Mocked<SnapshotStorage>;
+	const mockStorage = {
+		upload: jest.fn(),
+		download: jest.fn(),
+	} as unknown as jest.Mocked<SnapshotStorage>;
 
-    beforeEach(() => {
-        service = new SnapshotService({
-            updateRepo: mockUpdateRepo,
-            yjs: mockYjs,
-            storage: mockStorage,
-        });
-        jest.clearAllMocks();
-    });
+	const mockSyncClient = {
+		sync: jest.fn(),
+	} as unknown as jest.Mocked<WebsocketSyncClient>;
 
-    it('성공 시나리오: 데이터를 가져와서 병합 후 업로드하고 저장소를 정리해야 한다', async () => {
-        const roomId = 'test-room';
-        const mockBase = new Uint8Array([1, 2]);
-        const mockUpdates = [new Uint8Array([3]), new Uint8Array([4])];
-        const mockNewSnapshot = new Uint8Array([1, 2, 3, 4]);
+	beforeEach(() => {
+		service = new SnapshotService({
+			updateRepo: mockUpdateRepo,
+			yjs: mockYjs,
+			storage: mockStorage,
+			syncClient: mockSyncClient,
+		});
+		jest.clearAllMocks();
+	});
 
-        const mockPacket = {
-            lastEntryId: '123-0',
-            roomId: roomId,
-            updateFrameList: mockUpdates
-        };
+	it("성공 시나리오: 데이터를 가져와서 병합 후 업로드하고 저장소를 정리해야 한다", async () => {
+		const roomId = "test-room";
+		const mockBase = new Uint8Array([1, 2]);
+		const mockUpdates = [new Uint8Array([3]), new Uint8Array([4])];
+		const mockNewSnapshot = new Uint8Array([1, 2, 3, 4]);
 
-        mockStorage.download.mockResolvedValue(mockBase);
-        mockUpdateRepo.fetchAllUpdates.mockResolvedValue(mockPacket);
-        mockYjs.buildSnapshot.mockReturnValue(mockNewSnapshot);
+		const mockPacket = {
+			lastEntryId: "123-0",
+			roomId: roomId,
+			updateFrameList: mockUpdates,
+		};
 
-        await service.process({
-            entryId: 'test-entry',
-            roomId,
-            type: JobType.SNAPSHOT
-        });
+		const job = {
+			entryId: "test-entry",
+			roomId,
+			type: JobType.SNAPSHOT,
+		};
 
-        expect(mockStorage.download).toHaveBeenCalledWith(roomId);
-        expect(mockUpdateRepo.fetchAllUpdates).toHaveBeenCalledWith(roomId);
-        expect(mockUpdateRepo.trim).toHaveBeenCalledWith(roomId, mockPacket.lastEntryId);
-        expect(mockYjs.buildSnapshot).toHaveBeenCalledWith(mockBase, mockUpdates);
-        expect(mockStorage.upload).toHaveBeenCalledWith(roomId, mockNewSnapshot);
-    });
+		mockStorage.download.mockResolvedValue(mockBase);
+		mockUpdateRepo.fetchAllUpdates.mockResolvedValue(mockPacket);
+		mockYjs.buildUpdatedSnapshot.mockReturnValue(mockNewSnapshot);
 
-    it('S3에 기존 스냅샷이 없으면 에러를 던져야 한다 (NoSuchKey 등)', async () => {
-        const roomId = 'no-base-room';
+		await service.process(job);
 
-        mockStorage.download.mockRejectedValue(new Error('NoSuchKey: The specified key does not exist.'));
+		expect(mockStorage.download).toHaveBeenCalledWith(roomId);
+		expect(mockUpdateRepo.fetchAllUpdates).toHaveBeenCalledWith(roomId);
+		expect(mockYjs.buildUpdatedSnapshot).toHaveBeenCalledWith(
+			mockBase,
+			mockUpdates,
+		);
+		expect(mockStorage.upload).toHaveBeenCalledWith(roomId, mockNewSnapshot);
+		expect(mockUpdateRepo.trim).toHaveBeenCalledWith(
+			roomId,
+			mockPacket.lastEntryId,
+		);
+	});
 
-        await expect(
-            service.process({
-                entryId: 'test-entry',
-                roomId,
-                type: JobType.SNAPSHOT
-            })
-        ).rejects.toThrow('NoSuchKey');
+	it("S3에 기존 스냅샷이 없으면 에러를 던져야 한다 (NoSuchKey 등)", async () => {
+		const roomId = "no-base-room";
 
+		mockStorage.download.mockRejectedValue(
+			new Error("NoSuchKey: The specified key does not exist."),
+		);
 
-        expect(mockYjs.buildSnapshot).not.toHaveBeenCalled();
-        expect(mockStorage.upload).not.toHaveBeenCalled();
-        expect(mockUpdateRepo.trim).not.toHaveBeenCalled();
-    });
+		await expect(
+			service.process({
+				entryId: "test-entry",
+				roomId,
+				type: JobType.SNAPSHOT,
+			}),
+		).rejects.toThrow("NoSuchKey");
 
-    it('업로드에 실패하면 Redis를 비우지(trim) 않아야 한다', async () => {
-        const roomId = 'fail-room';
-        const lastEntryId = '456-0';
+		expect(mockYjs.buildUpdatedSnapshot).not.toHaveBeenCalled();
+		expect(mockStorage.upload).not.toHaveBeenCalled();
+		expect(mockUpdateRepo.trim).not.toHaveBeenCalled();
+	});
 
-        mockStorage.download.mockResolvedValue(new Uint8Array([1]));
-        mockUpdateRepo.fetchAllUpdates.mockResolvedValue({
-            lastEntryId,
-            roomId,
-            updateFrameList: [new Uint8Array([2])]
-        });
-        mockStorage.upload.mockRejectedValue(new Error('S3 Connection Failed'));
+	it("업로드에 실패하면 Redis를 비우지(trim) 않아야 한다", async () => {
+		const roomId = "fail-room";
+		const lastEntryId = "456-0";
 
-        await expect(service.process({
-            entryId: 'test-entry',
-            roomId,
-            type: JobType.SNAPSHOT
-        })).rejects.toThrow('S3 Connection Failed');
+		mockStorage.download.mockResolvedValue(new Uint8Array([1]));
+		mockUpdateRepo.fetchAllUpdates.mockResolvedValue({
+			lastEntryId,
+			roomId,
+			updateFrameList: [new Uint8Array([2])],
+		});
+		mockYjs.buildUpdatedSnapshot.mockReturnValue(new Uint8Array([1, 2]));
+		mockStorage.upload.mockRejectedValue(new Error("S3 Connection Failed"));
 
-        expect(mockUpdateRepo.trim).not.toHaveBeenCalled();
-    });
+		await expect(
+			service.process({
+				entryId: "test-entry",
+				roomId,
+				type: JobType.SNAPSHOT,
+			}),
+		).rejects.toThrow("S3 Connection Failed");
+
+		expect(mockUpdateRepo.trim).not.toHaveBeenCalled();
+	});
 });

--- a/backend/yjs-runner/package-lock.json
+++ b/backend/yjs-runner/package-lock.json
@@ -12,12 +12,14 @@
         "@aws-sdk/client-s3": "^3.990.0",
         "dotenv": "^17.3.1",
         "ioredis": "^5.9.3",
+        "jsonwebtoken": "^9.0.3",
         "lib0": "^0.2.117",
         "waait": "^1.0.5",
         "yjs": "^13.6.29"
       },
       "devDependencies": {
         "@types/jest": "^30.0.0",
+        "@types/jsonwebtoken": "^9.0.10",
         "@types/node": "^20.0.0",
         "jest": "^30.2.0",
         "nodemon": "^3.1.11",
@@ -3082,6 +3084,24 @@
         "pretty-format": "^30.0.0"
       }
     },
+    "node_modules/@types/jsonwebtoken": {
+      "version": "9.0.10",
+      "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-9.0.10.tgz",
+      "integrity": "sha512-asx5hIG9Qmf/1oStypjanR7iKTv0gXQ1Ov/jfrX6kS/EO0OFni8orbmGCn0672NHR3kXHwpAwR+B368ZGN/2rA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "20.19.33",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.33.tgz",
@@ -4052,6 +4072,12 @@
         "node": ">=8.0.0"
       }
     },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
@@ -4649,6 +4675,15 @@
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.286",
@@ -6097,6 +6132,49 @@
         "node": ">=6"
       }
     },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz",
+      "integrity": "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==",
+      "license": "MIT",
+      "dependencies": {
+        "jws": "^4.0.1",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/lazystream": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.1.tgz",
@@ -6214,10 +6292,46 @@
       "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==",
       "license": "MIT"
     },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+      "license": "MIT"
+    },
     "node_modules/lodash.isarguments": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
       "integrity": "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
       "license": "MIT"
     },
     "node_modules/lodash.memoize": {
@@ -6225,6 +6339,12 @@
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
       "integrity": "sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
       "license": "MIT"
     },
     "node_modules/long": {
@@ -6954,7 +7074,6 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -6982,7 +7101,6 @@
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
       "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"

--- a/backend/yjs-runner/package-lock.json
+++ b/backend/yjs-runner/package-lock.json
@@ -15,12 +15,15 @@
         "jsonwebtoken": "^9.0.3",
         "lib0": "^0.2.117",
         "waait": "^1.0.5",
+        "ws": "^8.19.0",
+        "y-protocols": "^1.0.7",
         "yjs": "^13.6.29"
       },
       "devDependencies": {
         "@types/jest": "^30.0.0",
         "@types/jsonwebtoken": "^9.0.10",
         "@types/node": "^20.0.0",
+        "@types/ws": "^8.18.1",
         "jest": "^30.2.0",
         "nodemon": "^3.1.11",
         "testcontainers": "^11.11.0",
@@ -3155,6 +3158,16 @@
       "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/yargs": {
       "version": "17.0.35",
@@ -8108,6 +8121,47 @@
       },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.19.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
+      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/y-protocols": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/y-protocols/-/y-protocols-1.0.7.tgz",
+      "integrity": "sha512-YSVsLoXxO67J6eE/nV4AtFtT3QEotZf5sK5BHxFBXso7VDUT3Tx07IfA6hsu5Q5OmBdMkQVmFZ9QOA7fikWvnw==",
+      "license": "MIT",
+      "dependencies": {
+        "lib0": "^0.2.85"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=8.0.0"
+      },
+      "funding": {
+        "type": "GitHub Sponsors ❤",
+        "url": "https://github.com/sponsors/dmonad"
+      },
+      "peerDependencies": {
+        "yjs": "^13.0.0"
       }
     },
     "node_modules/y18n": {

--- a/backend/yjs-runner/package.json
+++ b/backend/yjs-runner/package.json
@@ -14,6 +14,7 @@
   "type": "commonjs",
   "devDependencies": {
     "@types/jest": "^30.0.0",
+    "@types/jsonwebtoken": "^9.0.10",
     "@types/node": "^20.0.0",
     "jest": "^30.2.0",
     "nodemon": "^3.1.11",
@@ -27,6 +28,7 @@
     "@aws-sdk/client-s3": "^3.990.0",
     "dotenv": "^17.3.1",
     "ioredis": "^5.9.3",
+    "jsonwebtoken": "^9.0.3",
     "lib0": "^0.2.117",
     "waait": "^1.0.5",
     "yjs": "^13.6.29"

--- a/backend/yjs-runner/package.json
+++ b/backend/yjs-runner/package.json
@@ -16,6 +16,7 @@
     "@types/jest": "^30.0.0",
     "@types/jsonwebtoken": "^9.0.10",
     "@types/node": "^20.0.0",
+    "@types/ws": "^8.18.1",
     "jest": "^30.2.0",
     "nodemon": "^3.1.11",
     "testcontainers": "^11.11.0",
@@ -31,6 +32,8 @@
     "jsonwebtoken": "^9.0.3",
     "lib0": "^0.2.117",
     "waait": "^1.0.5",
+    "ws": "^8.19.0",
+    "y-protocols": "^1.0.7",
     "yjs": "^13.6.29"
   }
 }

--- a/infra/prod/Caddyfile
+++ b/infra/prod/Caddyfile
@@ -1,4 +1,4 @@
-api.episode.io.kr {
+api.episode.io.kr, http://10.0.26.165 {
 
     encode zstd gzip
 


### PR DESCRIPTION
Closes #423 

# 목적
Update가 Redis에 들어가지 못하고 drop 되는 상황에 대비해
Yjs runner가 직접 웹소켓에 연결되어 SYNC 프로토콜을 진행하는 로직을 구현합니다.

# 작업 내용
- MindmapTicketIssuer 구현
- Sync 로직 구현
- Redis 비밀번호 사용
- 프로덕션 인프라 파일 내부망 웹소켓 접속 허용하도록 수정
- 리팩토링

# 결과
<img width="425" height="88" alt="image" src="https://github.com/user-attachments/assets/6b157069-5816-4c0c-8709-540d24c97422" />

