### PR TITLE
[BE] refresh_token 에서 userId unique 처리 삭제(다른 디바이스에서도 중복 로그인 가능)

### DIFF
--- a/backend/api/src/main/java/com/yat2/episode/EpisodeApplication.java
+++ b/backend/api/src/main/java/com/yat2/episode/EpisodeApplication.java
@@ -5,11 +5,13 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 import org.springframework.boot.persistence.autoconfigure.EntityScan;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @EnableJpaAuditing
 @SpringBootApplication
 @EntityScan(basePackages = { "com.yat2.episode" })
 @ConfigurationPropertiesScan("com.yat2.episode")
+@EnableScheduling
 public class EpisodeApplication {
 
     public static void main(String[] args) {

--- a/backend/api/src/main/java/com/yat2/episode/auth/AuthService.java
+++ b/backend/api/src/main/java/com/yat2/episode/auth/AuthService.java
@@ -57,7 +57,7 @@ public class AuthService {
         refreshTokenService.validateSession(refreshToken);
 
         AuthTokens tokens = authJwtProvider.issueTokens(userId);
-        refreshTokenService.save(userId, tokens.refreshToken());
+        refreshTokenService.upsert(userId, tokens.refreshToken(), refreshToken);
 
         return tokens;
     }

--- a/backend/api/src/main/java/com/yat2/episode/auth/refresh/RefreshToken.java
+++ b/backend/api/src/main/java/com/yat2/episode/auth/refresh/RefreshToken.java
@@ -28,7 +28,7 @@ public class RefreshToken {
     private Long id;
 
     @OneToOne(fetch = FetchType.LAZY, optional = false)
-    @JoinColumn(name = "user_id", nullable = false, unique = true)
+    @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
     @Column(name = "token_hash", nullable = false, unique = true)

--- a/backend/api/src/main/java/com/yat2/episode/auth/refresh/RefreshToken.java
+++ b/backend/api/src/main/java/com/yat2/episode/auth/refresh/RefreshToken.java
@@ -7,7 +7,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
-import jakarta.persistence.OneToOne;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -23,11 +23,17 @@ import com.yat2.episode.user.User;
 @Table(name = "refresh_token")
 public class RefreshToken {
 
+    public RefreshToken(User userRef, String tokenHash, LocalDateTime expiresAt) {
+        this.user = userRef;
+        this.tokenHash = tokenHash;
+        this.expiresAt = expiresAt;
+    }
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @OneToOne(fetch = FetchType.LAZY, optional = false)
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 

--- a/backend/api/src/main/java/com/yat2/episode/auth/refresh/RefreshToken.java
+++ b/backend/api/src/main/java/com/yat2/episode/auth/refresh/RefreshToken.java
@@ -52,4 +52,9 @@ public class RefreshToken {
     public boolean isExpired() {
         return expiresAt.isBefore(LocalDateTime.now());
     }
+
+    public void rotate(String newTokenHash, LocalDateTime newExpiresAt) {
+        this.tokenHash = newTokenHash;
+        this.expiresAt = newExpiresAt;
+    }
 }

--- a/backend/api/src/main/java/com/yat2/episode/auth/refresh/RefreshTokenCleanupScheduler.java
+++ b/backend/api/src/main/java/com/yat2/episode/auth/refresh/RefreshTokenCleanupScheduler.java
@@ -1,0 +1,22 @@
+package com.yat2.episode.auth.refresh;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class RefreshTokenCleanupScheduler {
+
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    @Scheduled(cron = "0 0 4 ? * MON", zone = "Asia/Seoul")
+    @Transactional
+    public void cleanupExpiredRefreshTokens() {
+        int deleted = refreshTokenRepository.deleteExpired();
+        log.info("[RefreshTokenCleanup] deleted={}", deleted);
+    }
+}

--- a/backend/api/src/main/java/com/yat2/episode/auth/refresh/RefreshTokenRepository.java
+++ b/backend/api/src/main/java/com/yat2/episode/auth/refresh/RefreshTokenRepository.java
@@ -7,7 +7,6 @@ import org.springframework.data.jpa.repository.Query;
 import java.util.Optional;
 
 public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
-
     Optional<RefreshToken> findByTokenHash(String tokenHash);
 
     @Modifying
@@ -16,4 +15,7 @@ public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long
 
 
     void deleteByTokenHash(String tokenHash);
+
+    Optional<RefreshToken> findByTokenHashAndUser_KakaoId(String tokenHash, Long userId);
 }
+

--- a/backend/api/src/main/java/com/yat2/episode/auth/refresh/RefreshTokenRepository.java
+++ b/backend/api/src/main/java/com/yat2/episode/auth/refresh/RefreshTokenRepository.java
@@ -25,6 +25,10 @@ public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long
             @Param("expiresAt") LocalDateTime expiresAt
     );
 
+    @Modifying
+    @Query(value = "DELETE FROM refresh_token WHERE expires_at < NOW()", nativeQuery = true)
+    int deleteExpired();
+
     void deleteByUser_KakaoId(Long kakaoId);
 
     void deleteByTokenHash(String tokenHash);

--- a/backend/api/src/main/java/com/yat2/episode/auth/refresh/RefreshTokenRepository.java
+++ b/backend/api/src/main/java/com/yat2/episode/auth/refresh/RefreshTokenRepository.java
@@ -17,9 +17,6 @@ public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long
             value = """
                     INSERT INTO refresh_token (user_id, token_hash, expires_at)
                     VALUES (:userId, :tokenHash, :expiresAt)
-                    ON DUPLICATE KEY UPDATE
-                        token_hash = VALUES(token_hash),
-                        expires_at = VALUES(expires_at)
                     """, nativeQuery = true
     )
     void upsertByUserId(

--- a/backend/api/src/main/java/com/yat2/episode/auth/refresh/RefreshTokenRepository.java
+++ b/backend/api/src/main/java/com/yat2/episode/auth/refresh/RefreshTokenRepository.java
@@ -3,9 +3,7 @@ package com.yat2.episode.auth.refresh;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
-import java.time.LocalDateTime;
 import java.util.Optional;
 
 public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
@@ -13,24 +11,9 @@ public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long
     Optional<RefreshToken> findByTokenHash(String tokenHash);
 
     @Modifying
-    @Query(
-            value = """
-                    INSERT INTO refresh_token (user_id, token_hash, expires_at)
-                    VALUES (:userId, :tokenHash, :expiresAt)
-                    """, nativeQuery = true
-    )
-    void upsertByUserId(
-            @Param("userId") Long userId,
-            @Param("tokenHash") String tokenHash,
-            @Param("expiresAt") LocalDateTime expiresAt
-    );
-
-    @Modifying
     @Query("DELETE FROM RefreshToken rt WHERE rt.expiresAt < CURRENT_TIMESTAMP")
     int deleteExpired();
 
-
-    void deleteByUser_KakaoId(Long kakaoId);
 
     void deleteByTokenHash(String tokenHash);
 }

--- a/backend/api/src/main/java/com/yat2/episode/auth/refresh/RefreshTokenRepository.java
+++ b/backend/api/src/main/java/com/yat2/episode/auth/refresh/RefreshTokenRepository.java
@@ -26,8 +26,9 @@ public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long
     );
 
     @Modifying
-    @Query(value = "DELETE FROM refresh_token WHERE expires_at < NOW()", nativeQuery = true)
+    @Query("DELETE FROM RefreshToken rt WHERE rt.expiresAt < CURRENT_TIMESTAMP")
     int deleteExpired();
+
 
     void deleteByUser_KakaoId(Long kakaoId);
 

--- a/backend/api/src/main/java/com/yat2/episode/auth/refresh/RefreshTokenService.java
+++ b/backend/api/src/main/java/com/yat2/episode/auth/refresh/RefreshTokenService.java
@@ -15,6 +15,8 @@ import java.util.Base64;
 import com.yat2.episode.auth.jwt.AuthJwtProperties;
 import com.yat2.episode.global.exception.CustomException;
 import com.yat2.episode.global.exception.ErrorCode;
+import com.yat2.episode.user.User;
+import com.yat2.episode.user.UserRepository;
 
 @Slf4j
 @Service
@@ -23,13 +25,15 @@ public class RefreshTokenService {
 
     private final RefreshTokenRepository refreshTokenRepository;
     private final AuthJwtProperties authJwtProperties;
+    private final UserRepository userRepository;
 
     @Transactional
     public void save(Long userId, String refreshToken) {
         String tokenHash = hash(refreshToken);
         LocalDateTime expiresAt = LocalDateTime.now().plus(Duration.ofMillis(authJwtProperties.refreshTokenExpiry()));
-
-        refreshTokenRepository.upsertByUserId(userId, tokenHash, expiresAt);
+        User userRef = userRepository.getReferenceById(userId);
+        RefreshToken newRefreshToken = new RefreshToken(userRef, tokenHash, expiresAt);
+        refreshTokenRepository.save(newRefreshToken);
     }
 
     @Transactional(readOnly = true)

--- a/backend/api/src/main/resources/db/migration/V20260219_122333__enable_duplicate_users.sql
+++ b/backend/api/src/main/resources/db/migration/V20260219_122333__enable_duplicate_users.sql
@@ -1,0 +1,3 @@
+CREATE INDEX idx_refresh_token_user_id ON refresh_token(user_id);
+
+ALTER TABLE refresh_token DROP INDEX uk_refresh_token_user_id;


### PR DESCRIPTION
Closes #434

# 목적
다른 디바이스에서도 로그인을 허용합니다. (refresh 토큰 데이터가 덮어씌워져서 기존 로그인 디바이스에서 로그아웃되던 부분을 삭제)

# 작업 내용
- refresh token의 userId 중복가능 처리
- scheduler를 활용한 refresh token 정리 로직 

# 결과
