### PR TITLE
[FE] join 실패하면 participants api콜

### DIFF
--- a/frontend/src/features/auth/api/error.ts
+++ b/frontend/src/features/auth/api/error.ts
@@ -5,29 +5,20 @@ import { ERROR_CODES } from "@/shared/constants/error";
  * ApiError 타입 가드
  */
 export function isApiError(error: unknown): error is ApiError {
-    if (error === null) {
-        return false;
-    }
-
-    if (typeof error !== "object") {
-        return false;
-    }
-
-    const hasRequiredFields = "status" in error && "code" in error && "message" in error;
-
-    return hasRequiredFields;
+    return error instanceof ApiError;
 }
 
 /**
- * 다양한 에러를 안전하게 ApiError 타입으로 변환
+ * 어떤 형태의 에러든 안전하게 ApiError 인스턴스로 변환
  */
 export function toSafeApiError(error: unknown): ApiError {
     if (isApiError(error)) {
         return error;
     }
-    return {
-        status: 500,
-        code: "UNKNOWN_ERROR",
-        message: error instanceof Error ? ERROR_CODES.UNKNOWN_ERROR : "알 수 없는 오류가 발생했습니다.",
-    };
+
+    if (error instanceof Error) {
+        return new ApiError(500, "UNKNOWN_ERROR", ERROR_CODES.UNKNOWN_ERROR);
+    }
+
+    return new ApiError(500, "UNKNOWN_ERROR", "알 수 없는 오류가 발생했습니다.");
 }

--- a/frontend/src/features/auth/types/api.ts
+++ b/frontend/src/features/auth/types/api.ts
@@ -3,8 +3,23 @@ import { ERROR_CODES, ErrorCodeKey } from "@/shared/constants/error";
 /**
  * API 에러 응답
  */
-export type ApiError = {
-    status: number;
-    code: ErrorCodeKey;
-    message: (typeof ERROR_CODES)[keyof typeof ERROR_CODES];
-};
+export class ApiError extends Error {
+    public readonly status: number;
+    public readonly code: ErrorCodeKey;
+
+    constructor(status: number, code: ErrorCodeKey, message: (typeof ERROR_CODES)[keyof typeof ERROR_CODES] | string) {
+        super(message);
+
+        this.status = status;
+        this.code = code;
+        this.name = "ApiError";
+
+        // Error 클래스 상속 시 프로토타입 체인 유지 필수
+        Object.setPrototypeOf(this, ApiError.prototype);
+
+        // V8 엔진 환경(Chrome, Node.js 등)에서 스택 트레이스 정리
+        if (Error.captureStackTrace) {
+            Error.captureStackTrace(this, ApiError);
+        }
+    }
+}

--- a/frontend/src/features/mindmap/hooks/useJoinMindmapSession.ts
+++ b/frontend/src/features/mindmap/hooks/useJoinMindmapSession.ts
@@ -1,4 +1,5 @@
 import { useMutation } from "@tanstack/react-query";
+import { toast } from "sonner";
 
 import { ApiError } from "@/features/auth/types/api";
 import { post } from "@/shared/api/method";
@@ -8,15 +9,48 @@ export type JoinSessionResponse = {
     presignedUrl: string;
 };
 
-const fetchJoinSession = (mindmapId: string) => {
-    return post<JoinSessionResponse, { mindmapId: string }>({
-        endpoint: `/mindmaps/${mindmapId}/sessions/join`,
-    });
+const postParticipants = (mindmapId: string) => {
+    return post({ endpoint: `/mindmaps/${mindmapId}/participants` });
 };
 
-export const useJoinMindmapSession = () => {
+const fetchJoinSession = async (mindmapId: string, maxRetryCount: number): Promise<JoinSessionResponse> => {
+    try {
+        return await post<JoinSessionResponse, { mindmapId: string }>({
+            endpoint: `/mindmaps/${mindmapId}/sessions/join`,
+        });
+    } catch (e) {
+        if (!(e instanceof ApiError) || e.status !== 403) {
+            throw new Error("알 수 없는 오류입니다. 다시 시도해주세요.");
+        }
+
+        let retryCount = 0;
+        if (retryCount < maxRetryCount) {
+            try {
+                await postParticipants(mindmapId);
+
+                toast.success(`참여 등록이 완료되었습니다. 마인드맵 참여를 시작합니다.`);
+
+                retryCount += 1;
+                return await fetchJoinSession(mindmapId, retryCount + 1);
+            } catch (participantError) {
+                console.error("참여자 등록 실패:", participantError);
+                throw participantError;
+            }
+        }
+
+        throw e;
+    }
+};
+
+export const useJoinMindmapSession = ({
+    mindmapId,
+    maxRetryCount = 3,
+}: {
+    mindmapId: string;
+    maxRetryCount?: number;
+}) => {
     return useMutation<JoinSessionResponse, ApiError, string>({
-        mutationFn: fetchJoinSession,
+        mutationFn: () => fetchJoinSession(mindmapId, maxRetryCount),
         onError: (error) => {
             console.error("세션 참여 실패:", error.message);
         },

--- a/frontend/src/features/mindmap/hooks/useMindmapSession.ts
+++ b/frontend/src/features/mindmap/hooks/useMindmapSession.ts
@@ -10,7 +10,7 @@ type ConnectionStatus = "disconnected" | "connecting" | "connected";
 type SnapshotStatus = "idle" | "loading" | "success" | "error";
 
 type Props = {
-    mindmapId?: string;
+    mindmapId: string;
     enableAwareness?: boolean;
     userInfo: User | null;
 };
@@ -27,7 +27,7 @@ export function useMindmapSession({ mindmapId }: Props) {
     const [snapshotStatus, setSnapshotStatus] = useState<SnapshotStatus>("idle");
     const [connectionStatus, setConnectionStatus] = useState<ConnectionStatus>("disconnected");
 
-    const { mutate: joinSession } = useJoinMindmapSession();
+    const { mutate: joinSession } = useJoinMindmapSession({ mindmapId });
 
     useEffect(() => {
         if (!mindmapId) return;

--- a/frontend/src/features/mindmap/pages/MindmapDetailPage.tsx
+++ b/frontend/src/features/mindmap/pages/MindmapDetailPage.tsx
@@ -12,6 +12,10 @@ const COLORS = ["#34a7ff", "#fd69b9", "#0ed038", "#7749ff", "#ff913c"];
 export default function MindmapDetailPage() {
     const { mindmapId } = useParams<{ mindmapId: string }>();
 
+    if (!mindmapId) {
+        throw new Error("올바르지 않은 마인드맵 접근입니다.1");
+    }
+
     const { user: userInfo } = useAuth();
 
     const user = useMemo(() => {
@@ -36,10 +40,6 @@ export default function MindmapDetailPage() {
         }),
         [],
     );
-
-    if (!mindmapId) {
-        throw new Error("올바른 접근이 아닙니다.");
-    }
 
     if (!isSynced) {
         return (

--- a/frontend/src/shared/api/client.ts
+++ b/frontend/src/shared/api/client.ts
@@ -2,16 +2,11 @@ import { toSafeApiError } from "@/features/auth/api/error";
 import { getRefreshState, refreshToken, setRefreshState } from "@/features/auth/api/refresh";
 import { ApiError } from "@/features/auth/types/api";
 import type { FetchOptions } from "@/shared/api/types";
-import { ERROR_CODES } from "@/shared/constants/error";
+import { ERROR_CODES, ErrorCodeKey } from "@/shared/constants/error";
 
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL;
 
-const TOKEN_REFRESH_ERROR: ApiError = {
-    status: 401,
-    code: "TOKEN_EXPIRED",
-    message: ERROR_CODES.TOKEN_EXPIRED,
-};
-
+const TOKEN_REFRESH_ERROR = new ApiError(401, "TOKEN_EXPIRED", ERROR_CODES.TOKEN_EXPIRED);
 /**
  * 토큰 만료 시 자동 갱신 및 재시도하는 API 요청 래퍼
  * @throws {ApiError} 모든 에러를 ApiError 타입으로 변환하여 던집니다
@@ -79,12 +74,17 @@ export async function fetchWithAuth<T>(endpoint: string, options: FetchOptions =
         }
 
         if (!response.ok) {
-            const error: ApiError = await response.json().catch(() => ({
-                status: response.status,
-                code: "UNKNOWN_ERROR",
-                message: `HTTP ${response.status}: ${response.statusText}`,
-            }));
-            throw error;
+            let errorData;
+            try {
+                errorData = await response.json();
+            } catch {
+                errorData = {
+                    code: "UNKNOWN_ERROR" as ErrorCodeKey,
+                    message: `HTTP ${response.status}: ${response.statusText}`,
+                };
+            }
+
+            throw new ApiError(response.status, errorData.code, errorData.message);
         }
 
         if (response.status === 204) {
@@ -93,6 +93,10 @@ export async function fetchWithAuth<T>(endpoint: string, options: FetchOptions =
 
         return await response.json();
     } catch (error) {
+        if (error instanceof ApiError) {
+            throw error;
+        }
+
         throw toSafeApiError(error);
     }
 }


### PR DESCRIPTION
Closes #450

# 목적
팀 마인드맵에 접속했을 경우 요청을 함께 보내 참여할 수 있게 합니다.

# 작업 내용
## ➊ ApiError 수정
Error상속한 클래스 기반이 아니라서 그렇게 변경하였습니다.
이렇게 하면 catch문에서 instanceof로 걸러낼 수 있어(is로만 걸러내면 걸러낸 이후에 타입 추론이 잘 안될거같아요) 수정했습니다.

## ➋ join 실패 시 participant 요청
훅에서 maxRetryCount를 입력받고(기본 3) 이 횟수만큼 participants를 요청합니다.

# 결과
preview 가 없어서 테스트해보긴 어려운데, 일단 참여자가 아닐 경우 participants를 보내는 것은 확인했습니다.

