### PR TITLE
[FE] 무한 루프 로직과 참가 요청으로 인식할 수 있는 에러 코드로 수정

### DIFF
--- a/frontend/src/features/mindmap/hooks/useJoinMindmapSession.ts
+++ b/frontend/src/features/mindmap/hooks/useJoinMindmapSession.ts
@@ -33,7 +33,7 @@ const fetchJoinSession = async (
 
                 toast.success(`참여 등록이 완료되었습니다. 마인드맵 참여를 시작합니다.`);
 
-                return await fetchJoinSession(mindmapId, curRetryCount + 1);
+                return await fetchJoinSession(mindmapId, maxRetryCount, curRetryCount + 1);
             } catch (participantError) {
                 console.error("참여자 등록 실패:", participantError);
                 throw participantError;

--- a/frontend/src/features/mindmap/hooks/useJoinMindmapSession.ts
+++ b/frontend/src/features/mindmap/hooks/useJoinMindmapSession.ts
@@ -13,25 +13,27 @@ const postParticipants = (mindmapId: string) => {
     return post({ endpoint: `/mindmaps/${mindmapId}/participants` });
 };
 
-const fetchJoinSession = async (mindmapId: string, maxRetryCount: number): Promise<JoinSessionResponse> => {
+const fetchJoinSession = async (
+    mindmapId: string,
+    maxRetryCount: number,
+    curRetryCount: number = 0,
+): Promise<JoinSessionResponse> => {
     try {
         return await post<JoinSessionResponse, { mindmapId: string }>({
             endpoint: `/mindmaps/${mindmapId}/sessions/join`,
         });
     } catch (e) {
-        if (!(e instanceof ApiError) || e.status !== 403) {
+        if (!(e instanceof ApiError) || e.status !== 403 || curRetryCount >= maxRetryCount) {
             throw new Error("알 수 없는 오류입니다. 다시 시도해주세요.");
         }
 
-        let retryCount = 0;
-        if (retryCount < maxRetryCount) {
+        if (curRetryCount < maxRetryCount) {
             try {
                 await postParticipants(mindmapId);
 
                 toast.success(`참여 등록이 완료되었습니다. 마인드맵 참여를 시작합니다.`);
 
-                retryCount += 1;
-                return await fetchJoinSession(mindmapId, retryCount + 1);
+                return await fetchJoinSession(mindmapId, curRetryCount + 1);
             } catch (participantError) {
                 console.error("참여자 등록 실패:", participantError);
                 throw participantError;


### PR DESCRIPTION
Closes #454 

# 목적
무한 루프 로직을 고치고, 참가 요청으로 인식할 수 있는 에러 코드로 수정합니다.

# 작업 내용
## ➊ 에러 코드 수정
지금은 403(유저가 그 권한이 없다)으로 했는데, 실제로 404(그 마인드맵은 없다)가 와서 테스트 실패했습니다.
백엔드 합의 후 에러 코드 몇 줄 지 알려준다고 합니다.

## ➋ 무한루프 로직 수정
재귀로 함수를 호출하는데, curRetryCount는 계속 0이라서 무한 루프가 발생할 수 있습니다. 이를 수정합니다.

# 결과
이제는 이론상 됩니다.

