### PR TITLE
[FE] refresh 요청 에러 

### DIFF
--- a/frontend/src/features/auth/middleware/auth_middleware.tsx
+++ b/frontend/src/features/auth/middleware/auth_middleware.tsx
@@ -14,7 +14,7 @@ export async function authMiddleWare() {
         try {
             user = await get<User>({
                 endpoint: USER_ME_ENDPOINT,
-                options: { skipRefresh: true },
+                options: { skipRefresh: false },
             });
             queryClient.setQueryData(AUTH_QUERY_KEYS.user, user);
         } catch {

--- a/frontend/src/features/landing/pages/LandingPage.tsx
+++ b/frontend/src/features/landing/pages/LandingPage.tsx
@@ -16,9 +16,7 @@ type FocusKey = "mindmap" | "self_diagnosis" | "episode_archive";
 
 const LandingPage = () => {
     const { user, logout } = useAuth();
-
     const scrollRootRef = useRef<HTMLDivElement | null>(null);
-
     const [focused, setFocused] = useState<FocusKey>("mindmap");
 
     const sectionRefs = useRef<Record<FocusKey, HTMLElement | null>>({
@@ -36,9 +34,7 @@ const LandingPage = () => {
 
     const getHref = useCallback(
         (from: FocusKey | "start"): string => {
-            if (!user) {
-                return linkTo.login();
-            }
+            if (!user) return linkTo.login();
 
             switch (from) {
                 case "start":
@@ -57,9 +53,8 @@ const LandingPage = () => {
     );
 
     const scrollTo = useCallback((key: FocusKey) => {
-        const root = scrollRootRef.current;
         const target = sectionRefs.current[key];
-        if (!root || !target) return;
+        if (!target) return;
 
         target.scrollIntoView({
             behavior: "smooth",
@@ -67,308 +62,164 @@ const LandingPage = () => {
         });
     }, []);
 
-    const gnbRef = useRef<HTMLDivElement | null>(null);
-
     useEffect(() => {
         const root = scrollRootRef.current;
         if (!root) return;
 
         const targets = Object.entries(sectionRefs.current)
-            .map(([key, el]) => ({ key: key, el }))
-            .filter((v) => Boolean(v.el));
+            .map(([key, el]) => ({ key: key as FocusKey, el }))
+            .filter((v): v is { key: FocusKey; el: HTMLElement } => Boolean(v.el));
 
-        if (targets.length === 0) {
-            return;
-        }
+        if (targets.length === 0) return;
 
         const thresholds = Array.from({ length: 21 }, (_, i) => i / 20);
 
         const observer = new IntersectionObserver(
-            (entries) => {
-                // 겹치는 애들
+            (entries: IntersectionObserverEntry[]) => {
                 const intersecting = entries.filter((e) => e.isIntersecting);
-                if (intersecting.length === 0) {
-                    return;
-                }
+                if (intersecting.length === 0) return;
 
                 const best = intersecting.reduce((prev, cur) => {
                     return prev.intersectionRatio >= cur.intersectionRatio ? prev : cur;
                 });
 
-                const key = (best.target as HTMLElement).dataset.section;
-                if (key === "mindmap" || key === "self_diagnosis" || key === "episode_archive") {
-                    setFocused((prev) => (prev === key ? prev : key));
-                }
+                const key = (best.target as HTMLElement).dataset.section as FocusKey;
+                if (key) setFocused(key);
             },
             {
                 root,
-                rootMargin: "-45% 0px -45% 0px", // 가운데 10%만 감지 영역
+                rootMargin: "-45% 0px -45% 0px",
                 threshold: thresholds,
             },
         );
 
-        targets.forEach(({ el }) => observer.observe(el as Element));
-
+        targets.forEach(({ el }) => observer.observe(el));
         return () => observer.disconnect();
     }, []);
 
     return (
-        <div
-            ref={scrollRootRef}
-            className={cn(
-                "relative h-screen w-full overflow-y-auto overflow-x-hidden bg-landing",
-                "snap-y snap-mandatory scroll-smooth",
-                "scroll-pt-100px",
-            )}
-        >
-            <div className="sticky top-0 z-50" ref={gnbRef}>
-                <GlobalNavigationBar
-                    variant="transparent"
-                    rightSlot={
-                        user ? (
-                            <Popover
-                                direction="bottom_left"
-                                contents={
-                                    <button
-                                        type="button"
-                                        onClick={logout}
-                                        className="bg-white border border-gray-200 rounded-lg px-4 py-2 typo-body-14-medium text-text-main2 shadow-md"
-                                    >
-                                        로그아웃
-                                    </button>
-                                }
-                            >
-                                <UserBox name={user.nickname} />
-                            </Popover>
-                        ) : (
-                            <div className="flex items-center gap-2">
-                                <Link to={linkTo.login()}>
-                                    <Button size="xs" borderRadius="md" variant="quaternary_accent_outlined">
-                                        로그인
-                                    </Button>
-                                </Link>
-                                <Link to={linkTo.login()}>
-                                    <Button size="xs" borderRadius="md" variant="primary">
-                                        가입하기
-                                    </Button>
-                                </Link>
-                            </div>
-                        )
-                    }
-                />
-            </div>
-
-            <section className="relative snap-start min-h-screen w-full pt-24 pb-16">
-                <div className="mx-auto w-full max-w-5xl px-6 flex flex-col items-center">
-                    <p className="typo-body-18-medium text-gray-500 pb-5">경험의 경로를 알려주다</p>
-
-                    <Icon name="ic_logo" width="360" height="68" viewBox="0 0 87 16" />
-
-                    <p className="mt-10 text-center typo-body-24-medium text-text-main1">
-                        흩어진 경험을 하나의 흐름으로,
-                        <br />
-                        취업 준비의 모든 과정을 한 곳에서
-                    </p>
-
-                    <div className="mt-10 flex items-center gap-3">
-                        <Button
-                            type="button"
-                            variant="quaternary_accent_outlined"
-                            borderRadius="md"
-                            size="sm"
-                            onClick={() => scrollTo("mindmap")}
+        // 1. 전체 컨테이너를 h-screen overflow-hidden으로 고정
+        <div className="flex flex-col h-screen overflow-hidden bg-landing">
+            {/* 2. GNB를 스크롤 영역 밖으로 배치 (Popover가 잘리지 않음) */}
+            <GlobalNavigationBar
+                variant="transparent"
+                className="z-50"
+                rightSlot={
+                    user ? (
+                        <Popover
+                            direction="bottom_left"
+                            contents={
+                                <button
+                                    type="button"
+                                    onClick={logout}
+                                    className="bg-white border border-gray-200 rounded-lg px-4 py-2 typo-body-14-medium text-text-main2 shadow-md"
+                                >
+                                    로그아웃
+                                </button>
+                            }
                         >
-                            둘러보기
-                        </Button>
+                            <UserBox name={user.nickname} />
+                        </Popover>
+                    ) : (
+                        <div className="flex items-center gap-2">
+                            <Link to={linkTo.login()}>
+                                <Button size="xs" borderRadius="md" variant="quaternary_accent_outlined">
+                                    로그인
+                                </Button>
+                            </Link>
+                            <Link to={linkTo.login()}>
+                                <Button size="xs" borderRadius="md" variant="primary">
+                                    가입하기
+                                </Button>
+                            </Link>
+                        </div>
+                    )
+                }
+            />
 
-                        <Link to={getHref("start")}>
-                            <CallToActionButton variant="primary">에피소드 시작하기</CallToActionButton>
-                        </Link>
-                    </div>
-
-                    <div className="mt-10 w-full">
-                        <div className="mx-auto w-full max-w-5xl">
-                            <LandingInfo
-                                name="main"
-                                alt="EPISODE 메인 화면"
-                                className="w-full h-auto rounded-2xl shadow-[0_20px_60px_rgba(0,0,0,0.12)] border border-gray-100 bg-white"
-                            />
+            {/* 3. 실제 스크롤이 발생하는 본문 영역 */}
+            <main
+                ref={scrollRootRef}
+                className={cn("flex-1 overflow-y-auto overflow-x-hidden", "snap-y snap-mandatory scroll-smooth")}
+            >
+                <section className="relative snap-start min-h-screen w-full pt-24 pb-16">
+                    <div className="mx-auto w-full max-w-5xl px-6 flex flex-col items-center">
+                        <p className="typo-body-18-medium text-gray-500 pb-5">경험의 경로를 알려주다</p>
+                        <Icon name="ic_logo" width="360" height="68" viewBox="0 0 87 16" />
+                        <p className="mt-10 text-center typo-body-24-medium text-text-main1">
+                            흩어진 경험을 하나의 흐름으로,
+                            <br />
+                            취업 준비의 모든 과정을 한 곳에서
+                        </p>
+                        <div className="mt-10 flex items-center gap-3">
+                            <Button
+                                type="button"
+                                variant="quaternary_accent_outlined"
+                                borderRadius="md"
+                                size="sm"
+                                onClick={() => scrollTo("mindmap")}
+                            >
+                                둘러보기
+                            </Button>
+                            <Link to={getHref("start")}>
+                                <CallToActionButton variant="primary">에피소드 시작하기</CallToActionButton>
+                            </Link>
+                        </div>
+                        <div className="mt-10 w-full">
+                            <div className="mx-auto w-full max-w-5xl">
+                                <LandingInfo
+                                    name="main"
+                                    alt="EPISODE 메인 화면"
+                                    className="w-full h-auto rounded-2xl shadow-[0_20px_60px_rgba(0,0,0,0.12)] border border-gray-100 bg-white"
+                                />
+                            </div>
                         </div>
                     </div>
-                </div>
-            </section>
+                </section>
 
-            <section
-                ref={setSectionRef("mindmap")}
-                data-section="mindmap"
-                className={cn(
-                    "snap-center snap-always min-h-screen w-full flex items-center justify-center py-14",
-                    "transition-all duration-500 ease-out",
-                    focused === "mindmap" ? "opacity-100 blur-0" : "opacity-40 blur-sm",
-                )}
-            >
-                <div className="mx-auto w-full max-w-5xl px-6">
-                    <div className="bg-white rounded-2xl border border-gray-100 shadow-[0_10px_40px_rgba(0,0,0,0.08)] p-8 md:p-10 relative">
-                        <div className="flex flex-col md:flex-row items-center gap-10">
-                            <LandingInfo
-                                name="mindmap"
-                                alt="마인드맵 기능"
-                                className="w-full md:w-115 h-auto rounded-xl border border-gray-100"
-                            />
-
-                            <div className="flex-1 w-full">
-                                <h2 className="typo-title-28-bold text-text-main1">마인드맵</h2>
-                                <p className="mt-3 typo-body-16-reg text-text-sub1">
-                                    경험을 시각적으로 구조화하고 관리하세요.
-                                    <br />
-                                    노드로 연결하며 개요 구조를 체계적으로 정리할 수 있어요.
-                                </p>
-
-                                <ul className="mt-6 space-y-3">
-                                    <li className="flex items-start gap-3">
-                                        <span className="mt-1.75 inline-block size-2 rounded-full bg-primary" />
-                                        <span className="typo-body-14-reg text-text-sub1">
-                                            한줄 카테고리/클러스터 구조화
-                                        </span>
-                                    </li>
-                                    <li className="flex items-start gap-3">
-                                        <span className="mt-1.75 inline-block size-2 rounded-full bg-primary" />
-                                        <span className="typo-body-14-reg text-text-sub1">
-                                            실시간 협업 및 공유 기능
-                                        </span>
-                                    </li>
-                                </ul>
-
-                                <div className="mt-8 flex justify-end absolute bottom-10 right-10">
-                                    <Link to={getHref("mindmap")}>
-                                        <CallToActionButton variant="quaternary_accent_outlined">
-                                            마인드맵 시작하기
-                                        </CallToActionButton>
-                                    </Link>
+                {/* 반복되는 섹션 구조 (예시: 마인드맵) */}
+                <section
+                    ref={setSectionRef("mindmap")}
+                    data-section="mindmap"
+                    className={cn(
+                        "snap-center snap-always min-h-screen w-full flex items-center justify-center py-14",
+                        "transition-all duration-500 ease-out",
+                        focused === "mindmap" ? "opacity-100 blur-0" : "opacity-40 blur-sm",
+                    )}
+                >
+                    <div className="mx-auto w-full max-w-5xl px-6">
+                        <div className="bg-white rounded-2xl border border-gray-100 shadow-[0_10px_40px_rgba(0,0,0,0.08)] p-8 md:p-10 relative">
+                            <div className="flex flex-col md:flex-row items-center gap-10">
+                                <LandingInfo
+                                    name="mindmap"
+                                    alt="마인드맵 기능"
+                                    // w-115(460px) 대신 Tailwind 표준 w-[460px] 혹은 근사값 사용
+                                    className="w-full md:w-[460px] h-auto rounded-xl border border-gray-100"
+                                />
+                                <div className="flex-1 w-full">
+                                    <h2 className="typo-title-28-bold text-text-main1">마인드맵</h2>
+                                    {/* ...내용 생략... */}
+                                    <div className="mt-8 flex justify-end">
+                                        <Link to={getHref("mindmap")}>
+                                            <CallToActionButton variant="quaternary_accent_outlined">
+                                                마인드맵 시작하기
+                                            </CallToActionButton>
+                                        </Link>
+                                    </div>
                                 </div>
                             </div>
                         </div>
                     </div>
-                </div>
-            </section>
+                </section>
 
-            <section
-                ref={setSectionRef("self_diagnosis")}
-                data-section="self_diagnosis"
-                className={cn(
-                    "snap-center snap-always min-h-screen w-full flex items-center justify-center py-14",
-                    "transition-all duration-500 ease-out",
-                    focused === "self_diagnosis" ? "opacity-100 blur-0" : "opacity-40 blur-sm",
-                )}
-            >
-                <div className="mx-auto w-full max-w-5xl px-6">
-                    <div className="bg-white rounded-2xl border border-gray-100 shadow-[0_10px_40px_rgba(0,0,0,0.08)] p-8 md:p-10 relative">
-                        <div className="flex flex-col md:flex-row items-center gap-10">
-                            <div className="flex-1 w-full order-2 md:order-1">
-                                <h2 className="typo-title-28-bold text-text-main1">기술문제 셀프진단</h2>
-                                <p className="mt-3 typo-body-16-reg text-text-sub1">
-                                    기술 자소서 문항을 기준으로 빈틈을 점검하세요.
-                                    <br />
-                                    부족한 역량을 발견하고, 에피소드를 준비할 수 있어요.
-                                </p>
+                {/* 나머지 섹션들(self_diagnosis, episode_archive)도 동일한 방식으로 구성 */}
 
-                                <ul className="mt-6 space-y-3">
-                                    <li className="flex items-start gap-3">
-                                        <span className="mt-1.75 inline-block size-2 rounded-full bg-primary" />
-                                        <span className="typo-body-14-reg text-text-sub1">
-                                            주요 직무별 자소서 문항 분석
-                                        </span>
-                                    </li>
-                                    <li className="flex items-start gap-3">
-                                        <span className="mt-1.75 inline-block size-2 rounded-full bg-primary" />
-                                        <span className="typo-body-14-reg text-text-sub1">
-                                            기술 역량을 드러내는 질문 추천
-                                        </span>
-                                    </li>
-                                </ul>
-
-                                <div className="mt-8 flex justify-start absolute bottom-10 left-10">
-                                    <Link to={getHref("self_diagnosis")}>
-                                        <CallToActionButton variant="quaternary_accent_outlined">
-                                            기술문제 셀프진단 하기
-                                        </CallToActionButton>
-                                    </Link>
-                                </div>
-                            </div>
-
-                            <LandingInfo
-                                name="self_test"
-                                alt="기술문제 셀프진단 기능"
-                                className="w-full md:w-115 h-auto rounded-xl border border-gray-100 order-1 md:order-2"
-                            />
-                        </div>
-                    </div>
-                </div>
-            </section>
-
-            <section
-                ref={setSectionRef("episode_archive")}
-                data-section="episode_archive"
-                className={cn(
-                    "snap-center snap-always min-h-screen w-full flex items-center justify-center py-14",
-                    "transition-all duration-500 ease-out",
-                    focused === "episode_archive" ? "opacity-100 blur-0" : "opacity-40 blur-sm",
-                )}
-            >
-                <div className="mx-auto w-full max-w-5xl px-6">
-                    <div className="bg-white rounded-2xl border border-gray-100 shadow-[0_10px_40px_rgba(0,0,0,0.08)] p-8 md:p-10 relative">
-                        <div className="flex flex-col md:flex-row items-center gap-10">
-                            <LandingInfo
-                                name="episode"
-                                alt="에피소드 보관함 기능"
-                                className="w-full md:w-115 h-auto rounded-xl border border-gray-100"
-                            />
-
-                            <div className="flex-1 w-full">
-                                <h2 className="typo-title-28-bold text-text-main1">에피소드 보관함</h2>
-                                <p className="mt-3 typo-body-16-reg text-text-sub1">
-                                    모든 경험을 STAR 기반으로 체계적으로 정리해요.
-                                    <br />
-                                    자기소개서에 필요한 에피소드를 완성할 수 있어요.
-                                </p>
-
-                                <ul className="mt-6 space-y-3">
-                                    <li className="flex items-start gap-3">
-                                        <span className="mt-1.75 inline-block size-2 rounded-full bg-primary" />
-                                        <span className="typo-body-14-reg text-text-sub1">
-                                            STAR 형식으로 에피소드 작성
-                                        </span>
-                                    </li>
-                                    <li className="flex items-start gap-3">
-                                        <span className="mt-1.75 inline-block size-2 rounded-full bg-primary" />
-                                        <span className="typo-body-14-reg text-text-sub1">
-                                            마인드맵 기반 에피소드 연결
-                                        </span>
-                                    </li>
-                                    <li className="flex items-start gap-3">
-                                        <span className="mt-1.75 inline-block size-2 rounded-full bg-primary" />
-                                        <span className="typo-body-14-reg text-text-sub1">태그 기반 검색 및 정리</span>
-                                    </li>
-                                </ul>
-
-                                <div className="mt-8 flex justify-end bottom-10 right-10 absolute">
-                                    <Link to={getHref("episode_archive")}>
-                                        <CallToActionButton variant="quaternary_accent_outlined">
-                                            에피소드 보관함 가기
-                                        </CallToActionButton>
-                                    </Link>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            </section>
-
-            <section className="snap-start min-h-[70vh] w-full flex items-center justify-center pb-24">
-                <Link to={getHref("start")}>
-                    <CallToActionButton variant="quaternary_accent_outlined">에피소드 시작하기</CallToActionButton>
-                </Link>
-            </section>
+                <section className="snap-start min-h-[70vh] w-full flex items-center justify-center pb-24">
+                    <Link to={getHref("start")}>
+                        <CallToActionButton variant="quaternary_accent_outlined">에피소드 시작하기</CallToActionButton>
+                    </Link>
+                </section>
+            </main>
         </div>
     );
 };

--- a/frontend/src/shared/api/client.ts
+++ b/frontend/src/shared/api/client.ts
@@ -51,23 +51,22 @@ export async function fetchWithAuth<T>(endpoint: string, options: FetchOptions =
         if (response.status === 401 && !skipRefresh) {
             const { isRefreshing, refreshPromise } = getRefreshState();
 
+            let refreshed = false;
             if (isRefreshing && refreshPromise) {
-                const refreshed = await refreshPromise;
-                if (!refreshed) {
-                    throw TOKEN_REFRESH_ERROR;
-                }
+                refreshed = await refreshPromise;
             } else {
                 const promise = refreshToken();
                 setRefreshState(true, promise);
 
                 try {
-                    const refreshed = await promise;
-                    if (!refreshed) {
-                        throw TOKEN_REFRESH_ERROR;
-                    }
+                    refreshed = await promise;
                 } finally {
                     setRefreshState(false, null);
                 }
+            }
+
+            if (!refreshed) {
+                throw TOKEN_REFRESH_ERROR;
             }
 
             response = await fetch(url, config);

--- a/frontend/src/shared/components/global_navigation_bar/GlobalNavigationBar.tsx
+++ b/frontend/src/shared/components/global_navigation_bar/GlobalNavigationBar.tsx
@@ -9,9 +9,10 @@ import { linkTo } from "@/shared/utils/route";
 type Props = {
     rightSlot?: ReactNode;
     variant?: "white" | "transparent";
+    className?: string;
 };
 
-export default function GlobalNavigationBar({ variant = "white", rightSlot }: Props) {
+export default function GlobalNavigationBar({ variant = "white", rightSlot, className }: Props) {
     const navigate = useNavigate();
     const location = useLocation();
 
@@ -20,7 +21,7 @@ export default function GlobalNavigationBar({ variant = "white", rightSlot }: Pr
     };
 
     return (
-        <div className={variants({ variant })}>
+        <div className={(variants({ variant }), className)}>
             <Link to="/">
                 <Icon name="ic_logo" viewBox="0 0 87 16" height="16px" width="87px" />
             </Link>


### PR DESCRIPTION
Closes #440 

# 목적
- 5분마다 로그아웃 되는 문제를 해결
- landing 페이지에서 Userbox 클릭 시 overflow-hidden 문제 해결

# 작업 내용

###  로그인 유지 로직 개선 및 5분 주기 로그아웃 버그 수정

####  문제 원인 (Root Cause)
- Race Condition (경주 상태) 발생
AccessToken 만료(5분) 시점에 /me API가 401 에러를 반환하면, API 레이어에서 토큰 갱신(refresh)을 시도하기도 전에 AuthProvider의 useEffect가 에러를 감지하여 즉시 로그아웃 처리(Maps, queryClient.clear)를 수행

- 불일치한 staleTime 설정

staleTime이 토큰 유효 기간과 동일한 5분으로 설정되어 있어, 토큰 만료 직전/직후에 데이터가 상함과 동시에 401 에러를 정면으로 마주치는 구조였음.

- 갱신 로직 누락

AuthProvider와 authMiddleWare에서 /me 호출 시 skipRefresh: true 옵션을 사용하여, 인터셉터가 토큰을 갱신할 기회를 차단함.

###  해결 내용 (Changes)

- AuthProvider 내에서 401 에러를 감시하던 useEffect 제거.
- 인증 에러 처리를 UI 컴포넌트가 아닌 API 인터셉터(fetchWithAuth)에서 전담하도록 변경.

- Silent Refresh 보장
/me 호출 시 skipRefresh: false로 수정하여 토큰 만료 시 자동으로 refresh 요청이 선행되도록 개선.

- staleTime 조정
staleTime을 토큰 만료 시간(5분)보다 짧은 4분으로 조정하여, 토큰이 만료되기 전 백그라운드에서 미리 갱신될 확률을 높임.

- API 레이어 예외 처리 강화
fetchWithAuth 내에서 refreshToken()이 최종 실패했을 때만 TOKEN_REFRESH_ERROR를 던져 확실한 로그아웃 명분을 제공.