### PR TITLE
[BE] 톰캣 웹소켓 버퍼 사이즈 수정

### DIFF
--- a/backend/api/src/main/java/com/yat2/episode/collaboration/config/WebSocketConfig.java
+++ b/backend/api/src/main/java/com/yat2/episode/collaboration/config/WebSocketConfig.java
@@ -34,8 +34,6 @@ public class WebSocketConfig implements WebSocketConfigurer {
         container.setMaxTextMessageBufferSize(webSocketProperties.maxMessageSize());
         container.setMaxBinaryMessageBufferSize(webSocketProperties.maxMessageSize());
 
-        container.setMaxSessionIdleTimeout(300000L);
-
         return container;
     }
 }

--- a/backend/api/src/main/java/com/yat2/episode/collaboration/config/WebSocketConfig.java
+++ b/backend/api/src/main/java/com/yat2/episode/collaboration/config/WebSocketConfig.java
@@ -2,10 +2,12 @@ package com.yat2.episode.collaboration.config;
 
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.socket.config.annotation.EnableWebSocket;
 import org.springframework.web.socket.config.annotation.WebSocketConfigurer;
 import org.springframework.web.socket.config.annotation.WebSocketHandlerRegistry;
+import org.springframework.web.socket.server.standard.ServletServerContainerFactoryBean;
 
 import com.yat2.episode.collaboration.ws.HandshakeInterceptor;
 import com.yat2.episode.collaboration.ws.RelayHandler;
@@ -23,5 +25,17 @@ public class WebSocketConfig implements WebSocketConfigurer {
         registry.addHandler(relayHandler, webSocketProperties.pathPrefix() + "/{mindmapId}")
                 .addInterceptors(handshakeInterceptor)
                 .setAllowedOriginPatterns(webSocketProperties.allowedOriginPatterns().toArray(new String[0]));
+    }
+
+    @Bean
+    public ServletServerContainerFactoryBean createWebSocketContainer() {
+        ServletServerContainerFactoryBean container = new ServletServerContainerFactoryBean();
+
+        container.setMaxTextMessageBufferSize(webSocketProperties.maxMessageSize());
+        container.setMaxBinaryMessageBufferSize(webSocketProperties.maxMessageSize());
+
+        container.setMaxSessionIdleTimeout(300000L);
+
+        return container;
     }
 }

--- a/backend/api/src/main/java/com/yat2/episode/collaboration/config/WebSocketProperties.java
+++ b/backend/api/src/main/java/com/yat2/episode/collaboration/config/WebSocketProperties.java
@@ -8,6 +8,7 @@ import java.util.List;
 public record WebSocketProperties(
         int sendTimeout,
         int bufferSize,
+        int maxMessageSize,
         String pathPrefix,
         List<String> allowedOriginPatterns
 ) {}

--- a/backend/api/src/main/resources/application.yml
+++ b/backend/api/src/main/resources/application.yml
@@ -132,7 +132,8 @@ management:
 collaboration:
   ws:
     send-timeout: 10000
-    buffer-size: 524288
+    buffer-size: 1048576
+    max-message-size: 524288
     path-prefix: /ws/mindmap
     allowed-origin-patterns:
       - "http://localhost:*"


### PR DESCRIPTION
Closes #472 

# 목적
톰캣 기본 제한인 8KB가 넘는 큰 텍스트나, 노드 추가를 연속적으로 많이 할 경우 메시지 사이즈 제한으로 웹소켓 연결이 끊기는 상황이 생겨 이 문제를 해결합니다.

# 작업 내용
- 톰캣 메시지 사이즈 512KB로 상향
- 전송 버퍼 1MB로 상향
