### PR TITLE
[BE] 동시 편집 세션 재접속 직후 sync2 응답이 안올 수 있는 문제 해결

### DIFF
--- a/backend/api/src/main/java/com/yat2/episode/collaboration/SessionRegistry.java
+++ b/backend/api/src/main/java/com/yat2/episode/collaboration/SessionRegistry.java
@@ -112,7 +112,7 @@ public class SessionRegistry {
     }
 
     public List<WebSocketSession> findAllAlivePeers(UUID roomId, String excludeId) {
-        var sessions = rooms.get(roomId);
+        ConcurrentHashMap<String, WebSocketSession> sessions = rooms.get(roomId);
         if (sessions == null) return List.of();
 
         return sessions.values().stream().filter(WebSocketSession::isOpen).filter(s -> !s.getId().equals(excludeId))

--- a/backend/api/src/main/java/com/yat2/episode/collaboration/yjs/YjsMessageRouter.java
+++ b/backend/api/src/main/java/com/yat2/episode/collaboration/yjs/YjsMessageRouter.java
@@ -78,6 +78,7 @@ public class YjsMessageRouter {
                 return;
             }
         }
+        sessionRegistry.unicast(roomId, requester, YjsProtocolUtil.emptySync2Frame());
     }
 
     private void handleSync2(UUID roomId, WebSocketSession provider, byte[] payload) {


### PR DESCRIPTION
Closes #475 

# 목적
모종의 이유로 웹소켓 접속이 끊긴 직후 재접속을 할때 서버로부터 sync2 응답을 받지 못해 YDoc이 Synced 상태가 되지 않고
그 때문에 무한 로딩으로 대기하는 버그를 해결합니다.

웹소켓 연결이 끊긴 직후 바로 자동 재접속이 되므로 
찰나의 순간 동안에 실제로는 혼자 접속했음에도 두 명이 있다고 판단해(끊기기 전의 나, 재접속 하는 나)
서버가 직접 sync2 응답을 해주지 않는 경우가 있습니다.

# 작업 내용
- sync1 라우팅을 시도한 후 실패했을때 fallback으로 서버가 직접 응답합니다.
