### PR TITLE
[BE] session join 시 개인 마인드맵 확인 누락 수정

### DIFF
--- a/backend/api/src/main/java/com/yat2/episode/mindmap/MindmapAccessValidator.java
+++ b/backend/api/src/main/java/com/yat2/episode/mindmap/MindmapAccessValidator.java
@@ -36,8 +36,16 @@ public class MindmapAccessValidator {
         return mindmap;
     }
 
-    public Mindmap validateTeamMindmap(UUID mindmapId) {
+    public Mindmap validateTeamMindmapWithLock(UUID mindmapId) {
         Mindmap mindmap = mindmapRepository.findByIdWithLock(mindmapId)
+                .orElseThrow(() -> new CustomException(ErrorCode.MINDMAP_NOT_FOUND));
+        if (!mindmap.isShared()) throw new CustomException(ErrorCode.MINDMAP_ACCESS_FORBIDDEN);
+
+        return mindmap;
+    }
+
+    public Mindmap validateTeamMindmap(UUID mindmapId) {
+        Mindmap mindmap = mindmapRepository.findById(mindmapId)
                 .orElseThrow(() -> new CustomException(ErrorCode.MINDMAP_NOT_FOUND));
         if (!mindmap.isShared()) throw new CustomException(ErrorCode.MINDMAP_ACCESS_FORBIDDEN);
 

--- a/backend/api/src/main/java/com/yat2/episode/mindmap/MindmapService.java
+++ b/backend/api/src/main/java/com/yat2/episode/mindmap/MindmapService.java
@@ -232,7 +232,7 @@ public class MindmapService {
 
     @Transactional
     public MindmapSessionJoinRes joinMindmapSession(long userId, UUID mindmapId) {
-        mindmapAccessValidator.findMindmapOrThrow(mindmapId);
+        mindmapAccessValidator.validateTeamMindmap(mindmapId);
         MindmapParticipant participant = mindmapAccessValidator.findParticipantOrThrow(mindmapId, userId);
         String ticket = mindmapJwtProvider.issue(userId, mindmapId);
 

--- a/backend/api/src/main/java/com/yat2/episode/mindmap/MindmapService.java
+++ b/backend/api/src/main/java/com/yat2/episode/mindmap/MindmapService.java
@@ -209,7 +209,7 @@ public class MindmapService {
     @Transactional
     public MindmapSummaryRes saveMindmapParticipant(long userId, UUID mindmapId) {
         User user = userService.getUserOrThrow(userId);
-        Mindmap mindmap = mindmapAccessValidator.validateTeamMindmap(mindmapId);
+        Mindmap mindmap = mindmapAccessValidator.validateTeamMindmapWithLock(mindmapId);
 
         MindmapParticipant participant =
                 mindmapParticipantRepository.findByMindmapIdAndUserId(mindmapId, userId).orElseGet(() -> {

--- a/backend/api/src/test/java/com/yat2/episode/mindmap/MindmapServiceTest.java
+++ b/backend/api/src/test/java/com/yat2/episode/mindmap/MindmapServiceTest.java
@@ -45,6 +45,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doThrow;
@@ -393,6 +394,7 @@ class MindmapServiceTest {
             String objectKey = "snapshots/" + mindmapId;
             String expectedUrl = "https://s3.amazonaws.com/test-bucket/" + objectKey + "?token=abc";
 
+            given(mindmapAccessValidator.validateTeamMindmap(mindmapId)).willReturn(mindmap);
             given(mindmapAccessValidator.findParticipantOrThrow(mindmapId, testUserId)).willReturn(participant);
 
             given(s3ObjectKeyGenerator.generateMindmapSnapshotKey(mindmapId)).willReturn(objectKey);
@@ -401,21 +403,45 @@ class MindmapServiceTest {
             MindmapSessionJoinRes result = mindmapService.joinMindmapSession(testUserId, mindmapId);
 
             assertThat(result.presignedUrl()).isEqualTo(expectedUrl);
+
             MindmapTicketPayload payload = mindmapJwtProvider.verify(result.token());
             assertThat(payload.mindmapId()).isEqualTo(mindmapId);
             assertThat(payload.userId()).isEqualTo(testUserId);
+
+            verify(mindmapAccessValidator).validateTeamMindmap(mindmapId);
+            verify(mindmapAccessValidator).findParticipantOrThrow(mindmapId, testUserId);
         }
 
         @Test
         @DisplayName("실패: 존재하지 않는 마인드맵이면 MINDMAP_NOT_FOUND 예외가 발생한다")
         void should_throw_exception_when_mindmap_not_found() {
             UUID mindmapId = UUID.randomUUID();
-            given(mindmapAccessValidator.findParticipantOrThrow(mindmapId, testUserId)).willThrow(
+
+            given(mindmapAccessValidator.validateTeamMindmap(mindmapId)).willThrow(
                     new CustomException(ErrorCode.MINDMAP_NOT_FOUND));
 
             assertThatThrownBy(() -> mindmapService.joinMindmapSession(testUserId, mindmapId)).isInstanceOf(
                             CustomException.class).extracting(e -> ((CustomException) e).getErrorCode())
                     .isEqualTo(ErrorCode.MINDMAP_NOT_FOUND);
+
+            verify(mindmapAccessValidator).validateTeamMindmap(mindmapId);
+            verify(mindmapAccessValidator, never()).findParticipantOrThrow(any(), anyLong());
+            verifyNoInteractions(snapshotRepository, s3ObjectKeyGenerator);
+        }
+
+        @Test
+        @DisplayName("실패: 개인 마인드맵이면 MINDMAP_ACCESS_FORBIDDEN 예외가 발생한다")
+        void should_throw_exception_for_private_mindmap() {
+            UUID mindmapId = UUID.randomUUID();
+            given(mindmapAccessValidator.validateTeamMindmap(mindmapId)).willThrow(
+                    new CustomException(ErrorCode.MINDMAP_ACCESS_FORBIDDEN));
+
+            assertThatThrownBy(() -> mindmapService.joinMindmapSession(testUserId, mindmapId)).isInstanceOf(
+                            CustomException.class).extracting(e -> ((CustomException) e).getErrorCode())
+                    .isEqualTo(ErrorCode.MINDMAP_ACCESS_FORBIDDEN);
+
+            verify(mindmapAccessValidator).validateTeamMindmap(mindmapId);
+            verify(mindmapAccessValidator, never()).findParticipantOrThrow(any(), anyLong());
         }
     }
 

--- a/backend/api/src/test/java/com/yat2/episode/mindmap/MindmapServiceTest.java
+++ b/backend/api/src/test/java/com/yat2/episode/mindmap/MindmapServiceTest.java
@@ -320,7 +320,7 @@ class MindmapServiceTest {
             List<UUID> existingEpisodeIds = List.of(UUID.randomUUID(), UUID.randomUUID());
 
             given(userService.getUserOrThrow(testUserId)).willReturn(testUser);
-            given(mindmapAccessValidator.validateTeamMindmap(mindmapId)).willReturn(mindmap);
+            given(mindmapAccessValidator.validateTeamMindmapWithLock(mindmapId)).willReturn(mindmap);
             given(mindmapParticipantRepository.findByMindmapIdAndUserId(mindmapId, testUserId)).willReturn(
                     Optional.empty());
 
@@ -352,7 +352,7 @@ class MindmapServiceTest {
             MindmapParticipant existingParticipant = new MindmapParticipant(testUser, mindmap);
 
             given(userService.getUserOrThrow(testUserId)).willReturn(testUser);
-            given(mindmapAccessValidator.validateTeamMindmap(mindmapId)).willReturn(mindmap);
+            given(mindmapAccessValidator.validateTeamMindmapWithLock(mindmapId)).willReturn(mindmap);
             given(mindmapParticipantRepository.findByMindmapIdAndUserId(mindmapId, testUserId)).willReturn(
                     Optional.of(existingParticipant));
 
@@ -371,7 +371,7 @@ class MindmapServiceTest {
             UUID mindmapId = UUID.randomUUID();
 
             given(userService.getUserOrThrow(testUserId)).willReturn(testUser);
-            given(mindmapAccessValidator.validateTeamMindmap(mindmapId)).willThrow(
+            given(mindmapAccessValidator.validateTeamMindmapWithLock(mindmapId)).willThrow(
                     new CustomException(ErrorCode.MINDMAP_NOT_FOUND));
 
             assertThatThrownBy(() -> mindmapService.saveMindmapParticipant(testUserId, mindmapId)).isInstanceOf(


### PR DESCRIPTION
Closes #492

# 목적
session join 시 개인 마인드맵 확인 추가합니다.


# 작업 내용
- join 요청 처리 시 공유 마인드맵 여부 체크 후 MINDMAP_ACCESS_FORBIDDEN 체크합니다.

# 결과
