### PR TITLE
[BE] 개인 마인드맵이어도, 사용자의 마인드맵이면 join을 허용합니다.

### DIFF
--- a/backend/api/src/main/java/com/yat2/episode/mindmap/MindmapAccessValidator.java
+++ b/backend/api/src/main/java/com/yat2/episode/mindmap/MindmapAccessValidator.java
@@ -38,10 +38,9 @@ public class MindmapAccessValidator {
 
     public MindmapParticipant validateJoin(UUID mindmapId, long userId) {
         Mindmap mindmap = findMindmapOrThrow(mindmapId);
-        return mindmapParticipantRepository.findByMindmapIdAndUserId(mindmapId, userId).orElseThrow(() -> {
-            if (mindmap.isShared()) return new CustomException(ErrorCode.MINDMAP_PARTICIPANT_NOT_FOUND);
-            else return new CustomException(ErrorCode.MINDMAP_ACCESS_FORBIDDEN);
-        });
+        return mindmapParticipantRepository.findByMindmapIdAndUserId(mindmapId, userId).orElseThrow(
+                () -> new CustomException(mindmap.isShared() ? ErrorCode.MINDMAP_PARTICIPANT_NOT_FOUND :
+                                          ErrorCode.MINDMAP_ACCESS_FORBIDDEN));
     }
 
     public Mindmap validateTeamMindmapWithLock(UUID mindmapId) {

--- a/backend/api/src/main/java/com/yat2/episode/mindmap/MindmapAccessValidator.java
+++ b/backend/api/src/main/java/com/yat2/episode/mindmap/MindmapAccessValidator.java
@@ -50,12 +50,4 @@ public class MindmapAccessValidator {
 
         return mindmap;
     }
-
-    public Mindmap validateTeamMindmap(UUID mindmapId) {
-        Mindmap mindmap = mindmapRepository.findById(mindmapId)
-                .orElseThrow(() -> new CustomException(ErrorCode.MINDMAP_NOT_FOUND));
-        if (!mindmap.isShared()) throw new CustomException(ErrorCode.MINDMAP_ACCESS_FORBIDDEN);
-
-        return mindmap;
-    }
 }

--- a/backend/api/src/main/java/com/yat2/episode/mindmap/MindmapAccessValidator.java
+++ b/backend/api/src/main/java/com/yat2/episode/mindmap/MindmapAccessValidator.java
@@ -36,6 +36,14 @@ public class MindmapAccessValidator {
         return mindmap;
     }
 
+    public MindmapParticipant validateJoin(UUID mindmapId, long userId) {
+        Mindmap mindmap = findMindmapOrThrow(mindmapId);
+        return mindmapParticipantRepository.findByMindmapIdAndUserId(mindmapId, userId).orElseThrow(() -> {
+            if (mindmap.isShared()) return new CustomException(ErrorCode.MINDMAP_PARTICIPANT_NOT_FOUND);
+            else return new CustomException(ErrorCode.MINDMAP_ACCESS_FORBIDDEN);
+        });
+    }
+
     public Mindmap validateTeamMindmapWithLock(UUID mindmapId) {
         Mindmap mindmap = mindmapRepository.findByIdWithLock(mindmapId)
                 .orElseThrow(() -> new CustomException(ErrorCode.MINDMAP_NOT_FOUND));

--- a/backend/api/src/main/java/com/yat2/episode/mindmap/MindmapService.java
+++ b/backend/api/src/main/java/com/yat2/episode/mindmap/MindmapService.java
@@ -232,8 +232,7 @@ public class MindmapService {
 
     @Transactional
     public MindmapSessionJoinRes joinMindmapSession(long userId, UUID mindmapId) {
-        mindmapAccessValidator.validateTeamMindmap(mindmapId);
-        MindmapParticipant participant = mindmapAccessValidator.findParticipantOrThrow(mindmapId, userId);
+        MindmapParticipant participant = mindmapAccessValidator.validateJoin(mindmapId, userId);
         String ticket = mindmapJwtProvider.issue(userId, mindmapId);
 
         String presignedUrl =


### PR DESCRIPTION
Closes #495

# 목적
팀 마인드맵만 허용하던 join을 개인 마인드맵+사용자 본인 의 경우 허용합니다.

# 작업 내용
- join용 validate 추가
- test 코드 수정

# 결과
