### PR TITLE
[FE] 쿼드 트리 limit number 기본값 수정

### DIFF
--- a/frontend/src/features/mindmap/core/QuadTree.ts
+++ b/frontend/src/features/mindmap/core/QuadTree.ts
@@ -8,6 +8,8 @@ import { isIntersected, isPointInRect } from "@/shared/utils/rect_helper";
  *  limit: bounds에 저장할 수 있는 최대 노드 수
  *  children: 자식 쿼드
  */
+const DEFAULT_QUADTREE_LIMIT = 10;
+
 export default class QuadTree {
     private bounds: Rect;
     private points: Set<Point> = new Set();
@@ -19,7 +21,7 @@ export default class QuadTree {
         SE: QuadTree;
     } | null = null;
 
-    constructor(bounds: Rect, limit: number = 10) {
+    constructor(bounds: Rect, limit: number = DEFAULT_QUADTREE_LIMIT) {
         this.bounds = bounds;
         this.limit = limit;
     }

--- a/frontend/src/features/mindmap/core/QuadTree.ts
+++ b/frontend/src/features/mindmap/core/QuadTree.ts
@@ -19,7 +19,7 @@ export default class QuadTree {
         SE: QuadTree;
     } | null = null;
 
-    constructor(bounds: Rect, limit: number = 4) {
+    constructor(bounds: Rect, limit: number = 10) {
         this.bounds = bounds;
         this.limit = limit;
     }


### PR DESCRIPTION
Closes #498 

# 작업 내용
현재 items 생성시 0,0 위치로 보낸 후, 실제 렌더링 시 sync를 통해 실제 노드 좌표를 계산해서 다시 쿼드 트리에 삽입을 합니다.
그런데 초기 쿼드 트리 생성 시 0,0의 동일 점으로 들어가면서 쿼드트리 영역 split 을 무한 호출로 콜 스택 초과에러 발생

=> limit number를 items 생성 최대 개수 8개라 10개로 증가

# 결과

https://github.com/user-attachments/assets/cc90a2f2-6682-460d-b730-a8be1279a213


